### PR TITLE
Expose progress+completed data for fountain decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ CMakeCache.txt
 CMakeLists.txt.user
 CTestTestfile.cmake
 Makefile
+callgrind.out*
 cmake_install.cmake

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -95,8 +95,7 @@ inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream
 	CimbReader reader(img, _decoder, should_preprocess);
 
 	aligned_stream aligner(ostream, ostream.chunk_size());
-	unsigned res = do_decode(reader, aligner);
-	return res;
+	return do_decode(reader, aligner);
 }
 
 inline unsigned Decoder::decode(std::string filename, std::string output)

--- a/src/lib/fountain/FountainDecoder.h
+++ b/src/lib/fountain/FountainDecoder.h
@@ -31,6 +31,11 @@ public:
 		wirehair_free(_codec);
 	}
 
+	unsigned progress() const
+	{
+		return _seenBlocks.size();
+	}
+
 	size_t length() const
 	{
 		return _length;

--- a/src/lib/fountain/concurrent_fountain_decoder_sink.h
+++ b/src/lib/fountain/concurrent_fountain_decoder_sink.h
@@ -49,7 +49,8 @@ public:
 
 	void update_status()
 	{
-		// called under the writeMutex -- don't hold this for long!
+		// we call this under the writeMutex+readMutex. The `const`s are only under readMutex.
+		// just thought you ought to know
 		std::lock_guard<std::mutex> lock(_readMutex);
 		_done = _decoder.get_done();
 		_progress = _decoder.get_progress();

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -69,7 +69,11 @@ public:
 	{
 		std::vector<double> progress;
 		for (auto&& [slot, s] : _streams)
-			progress.push_back( s.progress() * 1.0 / s.blocks_required() );
+		{
+			unsigned br = s.blocks_required();
+			if (br)
+				progress.push_back( s.progress() * 1.0 / s.blocks_required() );
+		}
 		return progress;
 	}
 

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -9,9 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-
-// what we're trying to do here is have an object that can accept a complete (~8400 byte) buffer,
-// pull out the header, and give the appropriate decoder its bytes
+#include <vector>
 
 template <typename OUTSTREAM>
 class fountain_decoder_sink
@@ -35,7 +33,7 @@ public:
 
 	bool store(const FountainMetadata& md, const std::vector<uint8_t>& data)
 	{
-		std::string file_path = fmt::format("{}/{}.{}", _dataDir, md.encode_id(), md.file_size());
+		std::string file_path = fmt::format("{}/{}", _dataDir, get_filename(md));
 		OUTSTREAM f(file_path);
 		f.write((char*)data.data(), data.size());
 		return true;
@@ -57,6 +55,22 @@ public:
 	unsigned num_done() const
 	{
 		return _done.size();
+	}
+
+	std::vector<std::string> get_done() const
+	{
+		std::vector<std::string> done;
+		for (uint64_t id : _done)
+			done.push_back( get_filename(FountainMetadata(id)) );
+		return done;
+	}
+
+	std::vector<double> get_progress() const
+	{
+		std::vector<double> progress;
+		for (auto&& [slot, s] : _streams)
+			progress.push_back( s.progress() * 1.0 / s.blocks_required() );
+		return progress;
 	}
 
 	bool is_done(uint64_t id) const
@@ -108,6 +122,11 @@ protected:
 	uint8_t stream_slot(const FountainMetadata& md) const
 	{
 		return md.encode_id() & 0x7;
+	}
+
+	std::string get_filename(const FountainMetadata& md) const
+	{
+		return fmt::format("{}.{}", md.encode_id(), md.file_size());
 	}
 
 protected:

--- a/src/lib/fountain/fountain_decoder_stream.h
+++ b/src/lib/fountain/fountain_decoder_stream.h
@@ -20,7 +20,7 @@ public:
 
 	unsigned progress() const
 	{
-		return _progress;
+		return _decoder.progress();
 	}
 
 	unsigned blocks_required() const
@@ -46,7 +46,6 @@ public:
 	std::optional<std::vector<uint8_t>> decode()
 	{
 		// if we're full
-		++_progress;
 		_buffIndex = 0;
 		// we ignore the first 4 bytes. It's the sink's job to make sure we're getting the right stuff.
 		// we may, at some point, sanity check if data_size == [1]+[2]+[3]
@@ -84,5 +83,4 @@ protected:
 	std::vector<uint8_t> _buffer;
 	FountainDecoder _decoder;
 	unsigned _buffIndex = 0;
-	unsigned _progress = 0;
 };

--- a/src/lib/fountain/fountain_decoder_stream.h
+++ b/src/lib/fountain/fountain_decoder_stream.h
@@ -25,7 +25,7 @@ public:
 
 	unsigned blocks_required() const
 	{
-		return data_size() / std::max<unsigned>(block_size(), 1UL);
+		return (data_size() / block_size()) + 1;
 	}
 
 	unsigned block_size() const

--- a/src/lib/fountain/fountain_decoder_stream.h
+++ b/src/lib/fountain/fountain_decoder_stream.h
@@ -18,6 +18,16 @@ public:
 	{
 	}
 
+	unsigned progress() const
+	{
+		return _progress;
+	}
+
+	unsigned blocks_required() const
+	{
+		return data_size() / std::max<unsigned>(block_size(), 1UL);
+	}
+
 	unsigned block_size() const
 	{
 		return _buffer.size() - _headerSize;
@@ -36,6 +46,7 @@ public:
 	std::optional<std::vector<uint8_t>> decode()
 	{
 		// if we're full
+		++_progress;
 		_buffIndex = 0;
 		// we ignore the first 4 bytes. It's the sink's job to make sure we're getting the right stuff.
 		// we may, at some point, sanity check if data_size == [1]+[2]+[3]
@@ -73,4 +84,5 @@ protected:
 	std::vector<uint8_t> _buffer;
 	FountainDecoder _decoder;
 	unsigned _buffIndex = 0;
+	unsigned _progress = 0;
 };

--- a/src/lib/fountain/test/FountainEncodingTest.cpp
+++ b/src/lib/fountain/test/FountainEncodingTest.cpp
@@ -97,6 +97,7 @@ TEST_CASE( "FountainEncodingTest/testEncodingAndDecoding", "[unit]" )
 
 	assertEquals( 11, block_id );
 	assertEquals( 8, decoded_blocks );
+	assertEquals( decoded_blocks, decoder.progress() );
 }
 
 TEST_CASE( "FountainEncodingTest/testConsistency", "[unit]" )
@@ -174,5 +175,6 @@ TEST_CASE( "FountainEncodingTest/testWhichN", "[unit]" )
 
 	assertEquals( 96, block_id );
 	assertEquals( message, string((char*)final_result.data(), final_result.size()) );
+	assertEquals( 10, decoder.progress() );
 }
 

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -6,6 +6,7 @@
 #include "fountain_decoder_sink.h"
 
 #include "serialize/format.h"
+#include "serialize/str_join.h"
 #include "util/File.h"
 #include "util/MakeTempDirectory.h"
 #include <fstream>
@@ -73,6 +74,9 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 	assertEquals( 0, sink.num_streams() );
 	assertEquals( 2, sink.num_done() );
 
+	assertEquals( "", turbo::str::join(sink.get_progress()) );
+	assertEquals( "1.1600 0.1200", turbo::str::join(sink.get_done()) );
+
 	string contents = File(tempdir.path() / "0.1200").read_all();
 	assertEquals( 1200, contents.size() );
 	contents = File(tempdir.path() / "1.1600").read_all();
@@ -134,4 +138,7 @@ TEST_CASE( "FountainSinkTest/testSameFrameManyTimes", "[unit]" )
 
 	assertEquals( 1, sink.num_streams() );
 	assertEquals( 0, sink.num_done() );
+
+	assertEquals( "0.333333", turbo::str::join(sink.get_progress()) ); // 33% done
+	assertEquals( "", turbo::str::join(sink.get_done()) );
 }

--- a/src/lib/fountain/test/fountain_streamTest.cpp
+++ b/src/lib/fountain/test/fountain_streamTest.cpp
@@ -154,6 +154,8 @@ TEST_CASE( "FountainStreamTest/testDecode", "[unit]" )
 	assertEquals( 824, fds.block_size() );
 	assertEquals( 10000, fds.data_size() );
 	assertTrue( fds.good() );
+	assertEquals( fes->blocks_required(), fds.blocks_required() );
+	assertEquals( fes->blocks_required(), fds.progress() );
 
 	assertEquals( 15, fes->block_count() );
 	assertEquals( 13, fes->blocks_required() );


### PR DESCRIPTION
`concurrent_fountain_decoder_sink` needs tests pretty badly at this point. Otherwise, everything seems to be working?