### PR TITLE
Switch scanner to use OTSU by default

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -24,7 +24,7 @@
 			* this is neither reliable, nor representative of the usable case, however.
 
 * we have semi-reasonable excuses:
-	* the android app (cfc) is not currently using the GPU. OpenCV supports OpenCL (though you need a custom build on Android), but it's unclear to me how to copy data from the GPU -> CPU without bottlenecking system resources (ex: a 90ms pause every frame).
-	* additionally, cfc doesn't do anything useful with camera settings. We capture at ~25 fps, and are forced to discard a full 60% of the images due various ghosting and auto-focus issues. A 100% success rate won't happen -- some auto-focus will always be useful, and camera capture rate and the screen display rate are not going to be perfectly aligned, resulting in some number of screen-torn frames. But I'm pretty confident we can do better than 40%!
+	* the android app (cfc) doesn't do anything useful with camera settings. We capture at ~25 fps, and are forced to discard a full 60% of the images due various ghosting and auto-focus issues. A 100% success rate won't happen -- some auto-focus will always be useful, and camera capture rate and the screen display rate are not going to be perfectly aligned, resulting in some number of screen-torn frames. But I'm pretty confident we can do better than 40%!
 		* editorial comment: the android camera APIs are, to put it charitably, a raging tire fire
 		* cfc is currently using the legacy "camera" API. The camera2 API has eluded my comprehension.
+	* cfc is not currently using the GPU effectively. OpenCV on Android can code on the GPU via OpenCL (though you need a custom build), but... it's complicated...

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ And the quest for 100 kb/s over the air gap...
 
 `cimbar` is a proof-of-concept high-density 2D barcode format. Data is stored in a grid of colored tiles -- bits are encoded based on which tile is chosen, and which color is chosen to draw the tile. Reed Solomon error correction is applied on the data, to account for the lossy nature of the video -> digital decoding. Sub-1% error rates are expected, and corrected.
 
-`libcimbar`, the optimized implementation, includes a simple protocol for file encoding based on fountain codes (`wirehair`). Files of up to 33MB can be encoded in a series of cimbar codes, which can be output as a video feed or a series of images written to disk. The magic of fountain codes means that once enough distinct image frames have been decoded successfully, the file will be reconstructed successfully. This is true even if the images are received out of order, or if some have been corrupted or are missing.
+`libcimbar`, the optimized implementation, includes a simple protocol for file encoding based on fountain codes (`wirehair`). Files of up to 33MB can be encoded in a series of cimbar codes, which can be output as images or a live video feed. Once enough distinct image frames have been decoded successfully, the file will be reconstructed successfully. This is true even if the images are received out of order, or if some have been corrupted or are missing.
 
 ## Platforms
 
-The code is written in C++, and developed/tested on amd64+linux, arm64+android, and emscripten+wasm. It probably works, or can be made to work, on other platforms. Maybe.
+The code is written in C++, and developed/tested on amd64+linux, arm64+android, and emscripten+wasm. It probably works, or can be made to work, on other platforms.
 
 ## Library dependencies
 
@@ -44,7 +44,7 @@ make -j7
 make install
 ```
 
-By default, libcimbar will try to put its build products under `./dist/bin/`.
+By default, libcimbar will try to install build products under `./dist/bin/`.
 
 There is also a beta emscripten+WASM build for the encoder. See [WASM](WASM.md).
 

--- a/src/lib/extractor/ScanState.h
+++ b/src/lib/extractor/ScanState.h
@@ -64,7 +64,7 @@ protected:
 			if (_tally[i] == 0)
 				return NOOP;
 
-		int center = _tally[3];
+		float center = _tally[3];
 		for (int i = 1; i <= 5; ++i)
 		{
 			if (i == 3)

--- a/src/lib/extractor/Scanner.h
+++ b/src/lib/extractor/Scanner.h
@@ -98,20 +98,7 @@ inline unsigned Scanner::nextPowerOfTwoPlusOne(unsigned v)
 template <typename MAT, typename MAT2>
 inline void Scanner::threshold_fast(const MAT& img, MAT2& out)
 {
-	unsigned unit = std::min(img.cols, img.rows);
-	unit = nextPowerOfTwoPlusOne((unsigned)(unit * 0.05));
-	cv::adaptiveThreshold(img, out, 255, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, unit, -10);
-}
-
-template <>
-inline void Scanner::threshold_fast(const cv::UMat& img, cv::UMat& out)
-{
-	unsigned unit = std::min(img.cols, img.rows);
-	unit = nextPowerOfTwoPlusOne((unsigned)(unit * 0.05));
-	cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(4.0, cv::Size(unit, unit));
-	clahe->apply(img, out);
-
-	cv::threshold(out, out, 117, 255, cv::THRESH_BINARY);
+	cv::threshold(img, out, 117, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 }
 
 template <typename MAT>

--- a/src/lib/extractor/Scanner.h
+++ b/src/lib/extractor/Scanner.h
@@ -98,7 +98,7 @@ inline unsigned Scanner::nextPowerOfTwoPlusOne(unsigned v)
 template <typename MAT, typename MAT2>
 inline void Scanner::threshold_fast(const MAT& img, MAT2& out)
 {
-	cv::threshold(img, out, 117, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
+	cv::threshold(img, out, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
 }
 
 template <typename MAT>
@@ -112,7 +112,9 @@ inline cv::Mat Scanner::preprocess_image(const MAT& img)
 template <>
 inline cv::Mat Scanner::preprocess_image(const cv::UMat& img)
 {
-	return img.getMat(cv::ACCESS_FAST);
+	cv::UMat out;
+	preprocess_image(img, out);
+	return out.getMat(cv::ACCESS_FAST);
 }
 
 template <typename MAT>

--- a/src/lib/extractor/test/ExtractorTest.cpp
+++ b/src/lib/extractor/test/ExtractorTest.cpp
@@ -19,7 +19,7 @@ TEST_CASE( "ExtractorTest/testExtract", "[unit]" )
 
 	cv::Mat out = cv::imread(imgPath);
 	cv::cvtColor(out, out, cv::COLOR_BGR2RGB);
-	assertEquals( 0x2cab6b9cfa72624, image_hash::average_hash(out) );
+	assertEquals( 0x2cab639cfa72624, image_hash::average_hash(out) );
 }
 
 TEST_CASE( "ExtractorTest/testExtractMid", "[unit]" )
@@ -32,7 +32,7 @@ TEST_CASE( "ExtractorTest/testExtractMid", "[unit]" )
 
 	cv::Mat out = cv::imread(imgPath);
 	cv::cvtColor(out, out, cv::COLOR_BGR2RGB);
-	assertEquals( 0xc5f8225b6c6bc02, image_hash::average_hash(out) );
+	assertEquals( 0xc7f8205e686bc02, image_hash::average_hash(out) );
 }
 
 TEST_CASE( "ExtractorTest/testExtractUpscale", "[unit]" )
@@ -45,6 +45,6 @@ TEST_CASE( "ExtractorTest/testExtractUpscale", "[unit]" )
 
 	cv::Mat out = cv::imread(imgPath);
 	cv::cvtColor(out, out, cv::COLOR_BGR2RGB);
-	assertEquals( 0x29c64eac233f6394, image_hash::average_hash(out) );
+	assertEquals( 0x29c64eaca3356394, image_hash::average_hash(out) );
 }
 

--- a/src/lib/extractor/test/ScannerTest.cpp
+++ b/src/lib/extractor/test/ScannerTest.cpp
@@ -34,7 +34,7 @@ TEST_CASE( "ScannerTest/testPiecemealScan", "[unit]" )
 	std::vector<Anchor> c3;
 	for (const Anchor& c : c2)
 		sc.t3_scan_diagonal<ScanState_114>(c, [&c3] (const Anchor& p) { c3.push_back(p); });
-	assertStringContains("210+-24,914+-24", turbo::str::join(c3));
+	assertStringContains("210+-23,914+-24", turbo::str::join(c3));
 	assertStringContains("195+-25,61+-25", turbo::str::join(c3));
 	assertStringContains("1039+-22,887+-23", turbo::str::join(c3));
 
@@ -59,7 +59,7 @@ TEST_CASE( "ScannerTest/testBottomRightCorner", "[unit]" )
 
 	std::vector<Anchor> candidates;
 	int cutoff = sc.scan_primary(candidates);
-	assertEquals( 1754, cutoff );
+	assertEquals( 1766, cutoff );
 	assertEquals(
 	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23",
 	    turbo::str::join(candidates)
@@ -67,7 +67,7 @@ TEST_CASE( "ScannerTest/testBottomRightCorner", "[unit]" )
 
 	assertTrue( sc.add_bottom_right_corner(candidates, cutoff) );
 	assertEquals(
-	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,67+-24",
+	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,68+-24",
 	    turbo::str::join(candidates)
 	);
 }
@@ -87,7 +87,7 @@ TEST_CASE( "ScannerTest/testBottomRightCorner.2", "[unit]" )
 
 	assertTrue( sc.add_bottom_right_corner(candidates, cutoff) );
 	assertEquals(
-	    "29+-27,29+-27 993+-27,29+-27 29+-27,993+-27 994+-27,993+-27",
+	    "29+-27,29+-27 993+-27,29+-27 29+-27,993+-27 993+-27,993+-27",
 	    turbo::str::join(candidates)
 	);
 }
@@ -99,15 +99,15 @@ TEST_CASE( "ScannerTest/testBottomRightCorner.3", "[unit]" )
 
 	std::vector<Anchor> candidates;
 	int cutoff = sc.scan_primary(candidates);
-	assertEquals( 1607, cutoff );
+	assertEquals( 1575, cutoff );
 	assertEquals(
-	    "56+-24,166+-25 870+-24,133+-26 137+-20,910+-19",
+	    "56+-24,166+-25 870+-24,133+-25 137+-20,910+-18",
 	    turbo::str::join(candidates)
 	);
 
 	assertTrue( sc.add_bottom_right_corner(candidates, cutoff) );
 	assertEquals(
-	    "56+-24,166+-25 870+-24,133+-26 137+-20,910+-19 837+-18,898+-19",
+	    "56+-24,166+-25 870+-24,133+-25 137+-20,910+-18 837+-18,897+-18",
 	    turbo::str::join(candidates)
 	);
 }
@@ -119,15 +119,15 @@ TEST_CASE( "ScannerTest/testBottomRightCorner.4", "[unit]" )
 
 	std::vector<Anchor> candidates;
 	int cutoff = sc.scan_primary(candidates);
-	assertEquals( 1616, cutoff );
+	assertEquals( 1606, cutoff );
 	assertEquals(
-	    "189+-25,899+-23 157+-26,79+-25 924+-18,810+-19",
+	    "189+-25,899+-23 157+-26,79+-25 924+-18,811+-19",
 	    turbo::str::join(candidates)
 	);
 
 	assertTrue( sc.add_bottom_right_corner(candidates, cutoff) );
 	assertEquals(
-	    "189+-25,899+-23 157+-26,79+-25 924+-18,810+-19 911+-18,122+-20",
+	    "189+-25,899+-23 157+-26,79+-25 924+-18,811+-19 911+-18,122+-19",
 	    turbo::str::join(candidates)
 	);
 }
@@ -141,7 +141,7 @@ TEST_CASE( "ScannerTest/testExampleScan", "[unit]" )
 	std::vector<Anchor> candidates = sc.scan();
 	// order is top-left, top-right, bottom-left, bottom-right
 	assertEquals(
-	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,67+-24",
+	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,68+-24",
 	    turbo::str::join(candidates)
 	);
 }
@@ -155,7 +155,7 @@ TEST_CASE( "ScannerTest/testExampleScan.2", "[unit]" )
 	// order is top-left, top-right, bottom-left, bottom-right
 
 	assertEquals(
-	    "41+-25,196+-25 909+-25,183+-25 69+-23,1036+-23 896+-23,1036+-24",
+	    "41+-24,196+-25 909+-25,183+-25 69+-23,1036+-23 896+-23,1036+-23",
 	    turbo::str::join(candidates)
 	);
 }
@@ -169,7 +169,20 @@ TEST_CASE( "ScannerTest/testExampleScan.3", "[unit]" )
 	// order is top-left, top-right, bottom-left, bottom-right
 
 	assertEquals(
-	    "29+-27,29+-27 993+-27,29+-27 29+-27,993+-27 994+-27,993+-27",
+	    "29+-27,29+-27 993+-27,29+-27 29+-27,993+-27 993+-27,993+-27",
+	    turbo::str::join(candidates)
+	);
+}
+
+TEST_CASE( "ScannerTest/testExampleScan.Adaptive", "[unit]" )
+{
+	cv::Mat img = TestCimbar::loadSample("6bit/4_30_f0_627.jpg");
+	Scanner sc(img, false);
+
+	std::vector<Anchor> candidates = sc.scan();
+	// order is top-left, top-right, bottom-left, bottom-right
+	assertEquals(
+	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,67+-24",
 	    turbo::str::join(candidates)
 	);
 }
@@ -182,17 +195,17 @@ TEST_CASE( "ScannerTest/testScanEdges", "[unit]" )
 	std::vector<Anchor> candidates = sc.scan();
 	// order is top-left, top-right, bottom-left, bottom-right
 	assertEquals(
-	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,67+-24",
+	    "210+-25,914+-24 195+-25,61+-25 1039+-23,887+-23 1035+-23,68+-24",
 	    turbo::str::join(candidates)
 	);
 
 	Corners cs(candidates);
 	Midpoints mp;
 	std::vector<point<int>> edges = sc.scan_edges(cs, mp);
-	assertEquals( "177,490 623,38 1062,479 633,925", turbo::str::join(edges) );
+	assertEquals( "177,490 623,39 1061,479 633,925", turbo::str::join(edges) );
 
 	// check "expected" midpoints as well.
-	assertEquals( "202.549,490.27 623.371,64.0598 1037.01,479.559 632.657,900.234", turbo::str::join(mp.points()) );
+	assertEquals( "202.549,490.268 623.627,64.5719 1037.01,480.052 632.907,900.226", turbo::str::join(mp.points()) );
 }
 
 TEST_CASE( "ScannerTest/testSortTopToBottom", "[unit]" )

--- a/src/lib/extractor/test/SimpleCameraCalibrationTest.cpp
+++ b/src/lib/extractor/test/SimpleCameraCalibrationTest.cpp
@@ -27,5 +27,5 @@ TEST_CASE( "SimpleCameraCalibrationTest/testGetParams", "[unit]" )
 	assertEquals( "[320, 0, 640;\n"
 	              " 0, 240, 480;\n"
 	              " 0, 0, 1]", cam.str() );
-	assertEquals( "[-0.001852885275781788, 0, 0, 0]", dis.str() );
+	assertEquals( "[-0.001308300426007405, 0, 0, 0]", dis.str() );
 }

--- a/src/lib/extractor/test/UndistortTest.cpp
+++ b/src/lib/extractor/test/UndistortTest.cpp
@@ -19,7 +19,7 @@ TEST_CASE( "UndistortTest/testUndistort", "[unit]" )
 	Undistort<SimpleCameraCalibration> und;
 	assertTrue( und.undistort(img, out) );
 
-	assertEquals( 0x622c50583c3c0c72, image_hash::average_hash(out) );
+	assertEquals( 0x662450383e3c4c72, image_hash::average_hash(out) );
 }
 
 TEST_CASE( "UndistortTest/testUndistortAndExtract", "[unit]" )
@@ -33,5 +33,5 @@ TEST_CASE( "UndistortTest/testUndistortAndExtract", "[unit]" )
 	Extractor ex;
 	assertTrue( ex.extract(out, out) );
 
-	assertEquals( 0x8326daca7726690, image_hash::average_hash(out) );
+	assertEquals( 0x18f26faca7766794, image_hash::average_hash(out) );
 }


### PR DESCRIPTION
* it's not a full-fledged adaptive threshold algorithm, but it seems to do pretty well. Importantly, it's a decent performance boost with throughput implications (spoilers: 93 kb/s)
   * keeping around the adaptiveThreshold logic for now -- I can imagine cases where it will be useful (paper mode?)
* fix bug in ScanState
* refactor the Scanner preprocessing a bit