### PR TITLE
Decouple the symbol and color decode to enable better caching

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -120,14 +120,14 @@ decoded_data = error_correct(results)
 * `i`: the cell position
 * `bits`: the decoded bits for this decode
 * `distance`: the distance, or confidence, from the image hash when it selected a suitable symbol. Lower is better.
-* `drift`: an (x,y) offset that tracks local distortion for this decode. It is capped at 2px in all directions.
+* `drift`: an (x,y) offset that tracks local distortion for this decode. It is capped at 7px in all directions.
 * `deinterleave(i)` will return the "real" bit index of the bits, based on our interleave scheme -- the reverse of the encoder.
 * `position_tracker.update()` here informs `next_decode()` which cells it should prioritize next. Imagine a priority_queue based on `distance`.
 * `error_correct(results)` will reassemble the file, if error correction succeeds.
 
 The reason for complexity is multi-fold:
 * we have to reverse the interleave, to reassemble the file contents in the right order
-* we also decode the cells out of order, because the image hash's `distance` metric is also a (inverted) *confidence* metric. To minimize errors, we want to decode cells we are more confident about before cells we are less confident about.
+* we *decode* the cells out of order, using the image hash's `distance` metric as a (inverted) *confidence* metric. To minimize errors, we want to decode cells we are more confident about before cells we are less confident about.
 * the distance/confidence is used in combination with `drift` -- an (x,y) offset -- that tracks the local distortion for upcoming decodes. When we have higher confidence in a cell, its drift is preferred.
 
 ### Reasons for errors
@@ -138,9 +138,9 @@ There are a number of small problems that can conspire to create large problems 
 * some tiles might be too dark
 * the image might be misaligned
 * the image might suffer from lens distortion
-* the image might be too small, meaning the tiles have lost too much definition
+* the image might be too small, meaning the tiles have lost too much definition (see: blurry)
 
-Notably, these problems can also be *localized* in an image, meaning that while the right half is easy enough to decode, the left half becomes a disaster of misalignments and bad-guesses leading to worse misalignments and worse guesses. Interleaving and error correction can solve some of these problems, but at a certain point it becomes too much to deal with -- short of increasing the ECC level or input image resolution.
+Notably, these problems can also be *localized* in an image, meaning that while the right half might be easy enough to decode, the left half becomes a disaster of misalignments and bad-guesses leading to worse misalignments and worse guesses. Interleaving and error correction can solve some of these problems, but at a certain point it becomes too much to deal with -- short of increasing the ECC level or input image resolution.
 
 ### Example decode
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -14,10 +14,10 @@
 ## Current sustained benchmark
 
 * 4-color cimbar with ecc=30:
-	* 2,980,556 bytes (after compression) in 36s -> 662 kilobits/s
+	* 2,980,556 bytes (after compression) in 36s -> 662 kilobits/s (~82 KB/s)
 
 * 8-color cimbar with ecc=30:
-	* 2,980,556 bytes in 31s -> 769 kilobits/s
+	* 2,980,556 bytes in 31s -> 769 kilobits/s (~96 KB/s)
 
 * details:
 	* these numbers are use https://github.com/sz3/cfc, running with 4 CPU threads on a Qualcomm Snapdragon 625

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Behold: an experimental barcode format for air-gapped data transfer.
 
-It can sustain speeds of 770+ kilobits/s using nothing but a smartphone camera!
+It can sustain speeds of 770+ kilobits/s (~96 KB/s) using nothing but a smartphone camera!
 
 ## Explain?
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The code is written in C++, and developed/tested on amd64+linux, arm64+android, 
 * libcorrect - https://github.com/quiet/libcorrect
 * libpopcnt - https://github.com/kimwalisch/libpopcnt
 * PicoSHA2 - https://github.com/okdshin/PicoSHA2 (used for testing)
-* stb_image - https://github.com/nothings/stb (for the png loader)
+* stb_image - https://github.com/nothings/stb (for loading embedded pngs)
 * wirehair - https://github.com/catid/wirehair
 * zstd - https://github.com/facebook/zstd
 

--- a/WASM.md
+++ b/WASM.md
@@ -1,8 +1,12 @@
-### Demo
+## Demo encoder
 
 [cimbar.org](https://cimbar.org)
 
-### Build
+## Releases
+
+Both wasm and asm.js releases are available [here](https://github.com/sz3/libcimbar/releases/tag/latest). The wasm build is what cimbar.org uses. The asm.js build can be downloaded, extracted, and run locally.
+
+## Build
 
 To build opencv.js (and the static libraries we'll need to build against opencv)...
 ```
@@ -22,3 +26,7 @@ emcmake make -j7 install
 ```
 
 (do `-DUSE_WASM=2` to use asm.js instead of wasm)
+
+## What about a WASM cimbar decoder?
+
+Some day!

--- a/WASM.md
+++ b/WASM.md
@@ -4,7 +4,7 @@
 
 ## Releases
 
-Both wasm and asm.js releases are available [here](https://github.com/sz3/libcimbar/releases/tag/latest). The wasm build is what cimbar.org uses. The asm.js build can be downloaded, extracted, and run locally.
+wasm and asm.js releases are available [here](https://github.com/sz3/libcimbar/releases/latest). The wasm build is what cimbar.org uses. The asm.js build can be downloaded, extracted, and run in a local web browser.
 
 ## Build
 

--- a/src/lib/bit_file/test/bitbufferTest.cpp
+++ b/src/lib/bit_file/test/bitbufferTest.cpp
@@ -111,3 +111,36 @@ TEST_CASE( "bitbufferTest/testWriter.8", "[unit]" )
 	assertEquals( 225, bb.read(16, 8) );
 	assertEquals( 4, bb.read(24, 8) );
 }
+
+TEST_CASE( "bitbufferTest/testOverwrite", "[unit]" )
+{
+	bitbuffer bb;
+
+	bb.write(13,8064,6);
+	bb.write(7,8070,6);
+	bb.write(1,8076,6);
+	bb.write(5,8082,6);
+	bb.write(13,8088,6);
+	bb.write(7,8094,6);
+	bb.write(12,8100,6);
+	bb.write(14,8106,6);
+	bb.write(13,8112,6);
+	bb.write(7,8118,6);
+
+	bb.write(1,8064,2);
+	bb.write(0,8070,2);
+	bb.write(0,8076,2);
+	bb.write(3,8082,2);
+	bb.write(1,8088,2);
+	bb.write(0,8094,2);
+	bb.write(0,8100,2);
+	bb.write(2,8106,2);
+	bb.write(1,8112,2);
+	bb.write(0,8118,2);
+
+	assertEquals( 'u', bb.buffer()[0x3f2] );
+	assertEquals( 't', bb.buffer()[0x3f3] );
+	assertEquals( 's', (unsigned)bb.buffer()[0x3f4] );
+	assertEquals( '.', bb.buffer()[0x3f5] );
+	assertEquals( 't', bb.buffer()[0x3f6] );
+}

--- a/src/lib/cimb_translator/CMakeLists.txt
+++ b/src/lib/cimb_translator/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
 	FloodDecodePositions.h
 	Interleave.h
 	LinearDecodePositions.h
+	PositionData.h
 )
 
 add_library(cimb_translator STATIC ${SOURCES})

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -162,9 +162,10 @@ unsigned CimbDecoder::decode_color(const Cell& color_cell, const std::pair<int, 
 	if (_numColors <= 1)
 		return 0;
 
+	// TODO: should this check dimensions of color_cell?
 	// limit dimensions to ignore outer row/col. We want to look at the middle 6x6
 	Cell center = color_cell;
-	center.crop(2+drift.first, 2+drift.second, color_cell.cols()-4, color_cell.rows()-4);
+	center.crop(1+drift.first, 1+drift.second, color_cell.cols()-2, color_cell.rows()-2);
 	uchar r,g,b;
 	std::tie(r, g, b) = center.mean_rgb(Cell::SKIP);
 	return get_best_color(r, g, b);

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -157,28 +157,26 @@ unsigned CimbDecoder::get_best_color(uchar r, uchar g, uchar b) const
 	return best_fit;
 }
 
-unsigned CimbDecoder::decode_color(const Cell& color_cell, const std::pair<int, int>& drift) const
+unsigned CimbDecoder::decode_color(const Cell& color_cell) const
 {
 	if (_numColors <= 1)
 		return 0;
 
-	// TODO: should this check dimensions of color_cell?
+	// TODO: check/enforce dimensions of color_cell?
 	// limit dimensions to ignore outer row/col. We want to look at the middle 6x6
 	Cell center = color_cell;
-	center.crop(1+drift.first, 1+drift.second, color_cell.cols()-2, color_cell.rows()-2);
+	center.crop(1, 1, color_cell.cols()-2, color_cell.rows()-2);
 	uchar r,g,b;
 	std::tie(r, g, b) = center.mean_rgb(Cell::SKIP);
 	return get_best_color(r, g, b);
 }
 
-unsigned CimbDecoder::decode(const cv::Mat& color_cell) const
-{
-	unsigned drift_offset;
-	unsigned distance;
-	return decode(color_cell, Cell(color_cell), drift_offset, distance);
-}
-
 bool CimbDecoder::expects_binary_threshold() const
 {
 	return _ahashThreshold >= 0xFE;
+}
+
+unsigned CimbDecoder::symbol_bits() const
+{
+	return _symbolBits;
 }

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -13,18 +13,15 @@ class CimbDecoder
 public:
 	CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark=true, uchar ahashThreshold=0);
 
-	unsigned decode(const cv::Mat& color_cell) const;
-	template <typename MAT, typename CMAT>
-	unsigned decode(const MAT& cell, const CMAT& color_cell, unsigned& drift_offset, unsigned& best_distance) const;
-
 	unsigned get_best_symbol(image_hash::ahash_result& results, unsigned& drift_offset, unsigned& best_distance) const;
 	unsigned decode_symbol(const cv::Mat& cell, unsigned& drift_offset, unsigned& best_distance) const;
 	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance) const;
 
 	unsigned get_best_color(uchar r, uchar g, uchar b) const;
-	unsigned decode_color(const Cell& cell, const std::pair<int, int>& drift) const;
+	unsigned decode_color(const Cell& cell) const;
 
 	bool expects_binary_threshold() const;
+	unsigned symbol_bits() const;
 
 protected:
 	uint64_t get_tile_hash(unsigned symbol) const;
@@ -41,11 +38,3 @@ protected:
 	bool _dark;
 	uchar _ahashThreshold;
 };
-
-template <typename MAT, typename CMAT>
-inline unsigned CimbDecoder::decode(const MAT& cell, const CMAT& color_cell, unsigned& drift_offset, unsigned& best_distance) const
-{
-	unsigned bits = decode_symbol(cell, drift_offset, best_distance);
-	bits |= decode_color(color_cell, CellDrift::driftPairs[drift_offset]) << _symbolBits;
-	return bits;
-}

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -22,7 +22,6 @@ public:
 	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance) const;
 
 	unsigned get_best_color(uchar r, uchar g, uchar b) const;
-	unsigned decode_color(const cv::Mat& cell, const std::pair<int, int>& drift) const;
 	unsigned decode_color(const Cell& cell, const std::pair<int, int>& drift) const;
 
 	bool expects_binary_threshold() const;

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -86,8 +86,8 @@ unsigned CimbReader::read(position_data& pos)
 	_positions.update(i, drift, error_distance);
 
 	pos.i = i;
-	pos.x = xy.first + best_drift.first;
-	pos.y = xy.second + best_drift.second;
+	pos.x = x + best_drift.first;
+	pos.y = y + best_drift.second;
 	return bits;
 }
 

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -60,13 +60,13 @@ CimbReader::CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool nee
 {
 }
 
-unsigned CimbReader::read_color(const position_data& pos)
+unsigned CimbReader::read_color(const PositionData& pos)
 {
 	Cell color_cell(_image, pos.x, pos.y, Config::cell_size(), Config::cell_size());
 	return _decoder.decode_color(color_cell);
 }
 
-unsigned CimbReader::read(position_data& pos)
+unsigned CimbReader::read(PositionData& pos)
 {
 	if (done())
 		return 0;

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -63,7 +63,7 @@ CimbReader::CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool nee
 unsigned CimbReader::read_color(const position_data& pos)
 {
 	Cell color_cell(_image, pos.x, pos.y, Config::cell_size(), Config::cell_size());
-	return _decoder.decode_color(color_cell, {0,0});
+	return _decoder.decode_color(color_cell);
 }
 
 unsigned CimbReader::read(position_data& pos)

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -60,9 +60,9 @@ CimbReader::CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool nee
 {
 }
 
-unsigned CimbReader::read(unsigned& bits)
+unsigned CimbReader::read(position_data& pos)
 {
-	if (_positions.done())
+	if (done())
 		return 0;
 
 	// need coordinate, index, and drift from next position
@@ -74,12 +74,17 @@ unsigned CimbReader::read(unsigned& bits)
 
 	unsigned drift_offset = 0;
 	unsigned error_distance;
-	bits = _decoder.decode(cell, color_cell, drift_offset, error_distance);
+	unsigned bits = _decoder.decode(cell, color_cell, drift_offset, error_distance);
 
 	std::pair<int, int> best_drift = CellDrift::driftPairs[drift_offset];
 	drift.updateDrift(best_drift.first, best_drift.second);
 	_positions.update(i, drift, error_distance);
-	return i;
+	// x = xy.first + best_drift.x
+	// y = xy.second + best_drift.y
+	// return i,x,y
+	pos.i = i;
+
+	return bits;
 }
 
 bool CimbReader::done() const

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -22,6 +22,7 @@ public:
 	CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool needs_sharpen=false);
 
 	unsigned read(position_data& pos);
+	unsigned read_color(const position_data& pos);
 	bool done() const;
 
 	unsigned num_reads() const;

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -3,17 +3,10 @@
 
 #include "CimbDecoder.h"
 #include "FloodDecodePositions.h"
+#include "PositionData.h"
 
 #include "bit_file/bitbuffer.h"
 #include <opencv2/opencv.hpp>
-#include <string>
-
-struct position_data
-{
-	unsigned i = 0;
-	int x = 0;
-	int y = 0;
-};
 
 class CimbReader
 {
@@ -21,8 +14,8 @@ public:
 	CimbReader(const cv::Mat& img, const CimbDecoder& decoder, bool needs_sharpen=false);
 	CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool needs_sharpen=false);
 
-	unsigned read(position_data& pos);
-	unsigned read_color(const position_data& pos);
+	unsigned read(PositionData& pos);
+	unsigned read_color(const PositionData& pos);
 	bool done() const;
 
 	unsigned num_reads() const;

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -8,13 +8,20 @@
 #include <opencv2/opencv.hpp>
 #include <string>
 
+struct position_data
+{
+	unsigned i = 0;
+	int x = 0;
+	int y = 0;
+};
+
 class CimbReader
 {
 public:
 	CimbReader(const cv::Mat& img, const CimbDecoder& decoder, bool needs_sharpen=false);
 	CimbReader(const cv::UMat& img, const CimbDecoder& decoder, bool needs_sharpen=false);
 
-	unsigned read(unsigned& bits);
+	unsigned read(position_data& pos);
 	bool done() const;
 
 	unsigned num_reads() const;

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -21,12 +21,12 @@ void FloodDecodePositions::reset()
 	for (unsigned i = 0; i < _positions.size(); ++i)
 	{
 		_remaining.push_back(true);
-		_instructions.push_back({CellDrift(), ~0UL});
+		_instructions.push_back({CellDrift(), 0xFF});
 	}
 
 	// seed
-	int smallRowLen = _cellFinder.dimensions() - (2*_cellFinder.marker_size()) - 1;
-	int lastElem = _positions.size()-1;
+	uint16_t smallRowLen = _cellFinder.dimensions() - (2*_cellFinder.marker_size()) - 1;
+	uint16_t lastElem = _positions.size()-1;
 	_heap.push({0, 0});
 	_heap.push({smallRowLen, 0});
 	_heap.push({lastElem, 0});

--- a/src/lib/cimb_translator/FloodDecodePositions.h
+++ b/src/lib/cimb_translator/FloodDecodePositions.h
@@ -12,8 +12,8 @@ class FloodDecodePositions
 {
 public:
 	using iter = std::tuple<unsigned, CellPositions::coordinate, CellDrift>;
-	using decode_instructions = std::pair<CellDrift, unsigned>; // drift, best_prio
-	using decode_prio = std::tuple<unsigned, unsigned>; // index, prio
+	using decode_instructions = std::pair<CellDrift, uint8_t>; // drift, best_prio
+	using decode_prio = std::tuple<uint16_t, uint8_t>; // index, prio
 
 	class PrioCompare
 	{

--- a/src/lib/cimb_translator/FloodDecodePositions.h
+++ b/src/lib/cimb_translator/FloodDecodePositions.h
@@ -4,6 +4,7 @@
 #include "AdjacentCellFinder.h"
 #include "CellDrift.h"
 #include "CellPositions.h"
+#include <cstdint>
 #include <queue>
 #include <set>
 #include <tuple>

--- a/src/lib/cimb_translator/PositionData.h
+++ b/src/lib/cimb_translator/PositionData.h
@@ -1,0 +1,10 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+struct PositionData
+{
+	unsigned i = 0;
+	int x = 0;
+	int y = 0;
+};
+

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -37,6 +37,9 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 		position_data pos;
 		unsigned bits = cr.read(pos);
 		res[pos.i] = bits;
+
+		unsigned color_bits = cr.read_color(pos);
+		res[pos.i] |= color_bits << 4;
 		++count;
 	}
 
@@ -70,6 +73,9 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 		position_data pos;
 		unsigned bits = cr.read(pos);
 		res[pos.i] = bits;
+
+		unsigned color_bits = cr.read_color(pos);
+		res[pos.i] |= color_bits << 4;
 		++count;
 	}
 

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -32,7 +32,7 @@ TEST_CASE( "CimbReaderTest/testReadOnce", "[unit]" )
 	assertFalse(cr.done());
 
 	// read. The top left of the sample image happens to be 0, so it's not very exciting...
-	position_data pos;
+	PositionData pos;
 	unsigned bits = cr.read(pos);
 	assertEquals(0, bits);
 	assertEquals(0, pos.i);
@@ -57,7 +57,7 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 	std::map<unsigned, unsigned> res;
 	for (int c = 0; c < 22; ++c)
 	{
-		position_data pos;
+		PositionData pos;
 		unsigned bits = cr.read(pos);
 		res[pos.i] = bits;
 
@@ -71,7 +71,7 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 	        "12396=37 12397=38 12398=10 12399=15";
 	assertEquals( expected, turbo::str::join(res) );
 
-	position_data pos;
+	PositionData pos;
 	while (!cr.done())
 	{
 		cr.read(pos);
@@ -93,7 +93,7 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 	std::map<unsigned, unsigned> res;
 	for (int c = 0; c < 22; ++c)
 	{
-		position_data pos;
+		PositionData pos;
 		unsigned bits = cr.read(pos);
 		res[pos.i] = bits;
 
@@ -106,7 +106,7 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 	        "12201=0 12202=33 12297=46 12298=32 12299=34 12300=30 12301=32 12302=32 12396=37 12397=38 12398=10 12399=15";
 	assertEquals( expected, turbo::str::join(res) );
 
-	position_data pos;
+	PositionData pos;
 	while (!cr.done())
 		cr.read(pos);
 	assertTrue(cr.done());
@@ -124,7 +124,7 @@ TEST_CASE( "CimbReaderTest/testBad", "[unit]" )
 	// refuse to do anything
 	assertTrue( cr.done() );
 
-	position_data pos;
+	PositionData pos;
 	assertEquals( 0, cr.read(pos) );
 
 	assertTrue( cr.done() );

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -34,9 +34,9 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 	std::map<unsigned, unsigned> res;
 	for (int c = 0; c < 22; ++c)
 	{
-		unsigned bits;
-		unsigned index = cr.read(bits);
-		res[index] = bits;
+		position_data pos;
+		unsigned bits = cr.read(pos);
+		res[pos.i] = bits;
 		++count;
 	}
 
@@ -45,10 +45,10 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 	        "12396=37 12397=38 12398=10 12399=15";
 	assertEquals( expected, turbo::str::join(res) );
 
-	unsigned bits;
+	position_data pos;
 	while (!cr.done())
 	{
-		cr.read(bits);
+		cr.read(pos);
 		++count;
 	}
 	assertTrue(cr.done());
@@ -67,9 +67,9 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 	std::map<unsigned, unsigned> res;
 	for (int c = 0; c < 22; ++c)
 	{
-		unsigned bits;
-		unsigned index = cr.read(bits);
-		res[index] = bits;
+		position_data pos;
+		unsigned bits = cr.read(pos);
+		res[pos.i] = bits;
 		++count;
 	}
 
@@ -77,9 +77,9 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 	        "12201=0 12202=33 12297=46 12298=32 12299=34 12300=30 12301=32 12302=32 12396=37 12397=38 12398=10 12399=15";
 	assertEquals( expected, turbo::str::join(res) );
 
-	unsigned bits;
+	position_data pos;
 	while (!cr.done())
-		cr.read(bits);
+		cr.read(pos);
 	assertTrue(cr.done());
 }
 
@@ -95,8 +95,8 @@ TEST_CASE( "CimbReaderTest/testBad", "[unit]" )
 	// refuse to do anything
 	assertTrue( cr.done() );
 
-	unsigned bits;
-	assertEquals( 0, cr.read(bits) );
+	position_data pos;
+	assertEquals( 0, cr.read(pos) );
 
 	assertTrue( cr.done() );
 }

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -22,6 +22,29 @@ namespace {
 }
 #include "serialize/str_join.h"
 
+TEST_CASE( "CimbReaderTest/testReadOnce", "[unit]" )
+{
+	cv::Mat sample = TestCimbar::loadSample("6bit/4color_ecc30_fountain_0.png");
+
+	CimbDecoder decoder(4, 2);
+	CimbReader cr(sample, decoder);
+
+	assertFalse(cr.done());
+
+	// read. The top left of the sample image happens to be 0, so it's not very exciting...
+	position_data pos;
+	unsigned bits = cr.read(pos);
+	assertEquals(0, bits);
+	assertEquals(0, pos.i);
+	assertEquals(62, pos.x);
+	assertEquals(8, pos.y);
+
+	unsigned color_bits = cr.read_color(pos);
+	assertEquals(0, color_bits);
+
+	assertFalse(cr.done());
+}
+
 TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 {
 	cv::Mat sample = TestCimbar::loadSample("6bit/4color_ecc30_fountain_0.png");
@@ -39,7 +62,7 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 		res[pos.i] = bits;
 
 		unsigned color_bits = cr.read_color(pos);
-		res[pos.i] |= color_bits << 4;
+		res[pos.i] |= color_bits << decoder.symbol_bits();
 		++count;
 	}
 
@@ -75,7 +98,7 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 		res[pos.i] = bits;
 
 		unsigned color_bits = cr.read_color(pos);
-		res[pos.i] |= color_bits << 4;
+		res[pos.i] |= color_bits << decoder.symbol_bits();
 		++count;
 	}
 

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -64,14 +64,14 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 {
 	bitbuffer bb(_bitsPerOp * 1550);
 	std::vector<unsigned> interleaveLookup = Interleave::interleave_reverse(reader.num_reads(), _interleaveBlocks, _interleavePartitions);
-	std::array<position_data, 12400> colorPositions; // 12400 = 1500 * 8, aka the number of cells. This should probably be determined at runtime
+	std::array<PositionData, 12400> colorPositions; // 12400 = 1500 * 8, aka the number of cells. This should probably be determined at runtime
 
 	// read symbols first
 	while (!reader.done())
 	{
 		// reader is in charge of the cell index (i) calculation
 		// we can compute the bitindex ('index') here, but only the reader will know the right cell index...
-		position_data pos;
+		PositionData pos;
 		unsigned bits = reader.read(pos);
 
 		unsigned bitPos = interleaveLookup[pos.i] * _bitsPerOp;
@@ -82,7 +82,7 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 
 	// then decode colors.
 	// the symbol+color decode could be done as one pass, but doing it as two gives us more control of the caches
-	for (const position_data& p : colorPositions)
+	for (const PositionData& p : colorPositions)
 	{
 		unsigned bits = reader.read_color(p);
 		bb.write(bits, p.i, _colorBits);

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -64,13 +64,16 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 {
 	bitbuffer bb(_bitsPerOp * 1550);
 	std::vector<unsigned> interleaveLookup = Interleave::interleave_reverse(reader.num_reads(), _interleaveBlocks, _interleavePartitions);
+
+	// tuple(xpos, ypos, bitPos)
+	//std::vector<>;
 	while (!reader.done())
 	{
 		// reader should probably be in charge of the cell index (i) calculation
 		// we can compute the bitindex ('index') here, but only the reader will know the right cell index...
-		unsigned bits = 0;
-		unsigned i = reader.read(bits);
-		unsigned bitPos = interleaveLookup[i] * _bitsPerOp;
+		position_data pos;
+		unsigned bits = reader.read(pos);
+		unsigned bitPos = interleaveLookup[pos.i] * _bitsPerOp;
 		bb.write(bits, bitPos, _bitsPerOp);
 	}
 

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -64,17 +64,28 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 {
 	bitbuffer bb(_bitsPerOp * 1550);
 	std::vector<unsigned> interleaveLookup = Interleave::interleave_reverse(reader.num_reads(), _interleaveBlocks, _interleavePartitions);
+	std::array<position_data, 12400> colorPositions; // 12400 = 1500 * 8, aka the number of cells. This should probably be determined at runtime
 
-	// tuple(xpos, ypos, bitPos)
-	//std::vector<>;
+	// read symbols first
 	while (!reader.done())
 	{
-		// reader should probably be in charge of the cell index (i) calculation
+		// reader is in charge of the cell index (i) calculation
 		// we can compute the bitindex ('index') here, but only the reader will know the right cell index...
 		position_data pos;
 		unsigned bits = reader.read(pos);
+
 		unsigned bitPos = interleaveLookup[pos.i] * _bitsPerOp;
 		bb.write(bits, bitPos, _bitsPerOp);
+
+		colorPositions[pos.i] = {bitPos, pos.x, pos.y};
+	}
+
+	// then decode colors.
+	// the symbol+color decode could be done as one pass, but doing it as two gives us more control of the caches
+	for (const position_data& p : colorPositions)
+	{
+		unsigned bits = reader.read_color(p);
+		bb.write(bits, p.i, _colorBits);
 	}
 
 	reed_solomon_stream rss(ostream, _eccBytes);

--- a/src/lib/encoder/test/DecoderTest.cpp
+++ b/src/lib/encoder/test/DecoderTest.cpp
@@ -46,3 +46,15 @@ TEST_CASE( "DecoderTest/testDecodeEcc", "[unit]" )
 	assertEquals( "382c76644a4dff475c5793c5fe061e35e47be252010d29aeaf8d93ee6a3f7045", get_hash(decodedFile) );
 }
 
+TEST_CASE( "DecoderTest/testDecode.Sample", "[unit]" )
+{
+	// regression test -- useful for now, but is very brittle
+	MakeTempDirectory tempdir;
+
+	Decoder dec(0);
+	std::string decodedFile = tempdir.path() / "testDecode.txt";
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4_30_f0_627_extract.jpg"), decodedFile);
+	assertEquals( 9300, bytesDecoded );
+
+	assertEquals( "3de927c8aa0221807a2784210160cdc17567eb587bf01233d166900aadf14bf5", get_hash(decodedFile) );
+}


### PR DESCRIPTION
`CimbDecoder.decode_color()` iterates over image pixels, which I'd noted (https://github.com/sz3/libcimbar/pull/12) can blow up the caches. One of my theories was that it might be beneficial to attempt a 2-pass approach: do the symbol decodes first, then the color decodes.

This is beneficial not just because we're doing all the color decodes at once, but because the symbol decoding occurs in a "random"-ish order (chasing the highest-confidence cells, wherever that leads). Doing the color decodes after symbol decoding is done allows us to choose what order to decode color cells in.

In practice, it seems to make for a ~10% speedup on the symbol+color decode loop.