### PR TITLE
Encoder improvements. 118 KB/s

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -3,7 +3,7 @@
 
 ## The premise
 
-Conceptually, cimbar is built on top of `image hashing`:
+Cimbar is a grid of colored tiles. Conceptually, it is built on the idea of `image hashing`:
 
 ![example image hash](https://github.com/sz3/cimbar-samples/blob/v0.5/docs/imagehash.png)
 
@@ -84,7 +84,7 @@ These properties may appear to be magical as you consider them more, and they do
 2. wirehair requires the file contents to be stored in RAM
 	* this relates to the size limit!
 
-This constraint is less of an obstacle than it may seem -- the fountain codes are essentially being used as a wire format, and the encoder and decoder could agree on a scheme to split up, and then reassemble, larger files. Cimbar does not yet implement this, however!
+This constraint is less of an obstacle than it may seem -- the fountain codes are essentially being used as a wire format, and the encoder and decoder could agree on a scheme to split up, and then reassemble, larger files. Cimbar does not (yet?) implement this, however!
 
 ## Implementation: Decoder
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -14,10 +14,10 @@
 ## Current sustained benchmark
 
 * 4-color cimbar with ecc=30:
-	* 2,980,556 bytes (after compression) in 31s -> 769 kilobits/s (~96 KB/s)
+	* 4,717,525 bytes (after compression) in 45s -> 838 kilobits/s (~104 KB/s)
 
 * 8-color cimbar with ecc=30:
-	* 2,980,556 bytes in 29s -> 822 kilobits/s (~102 KB/s)
+	* 4,717,525 bytes in 40s -> 943 kilobits/s (~118 KB/s)
 
 * details:
 	* these numbers are using https://github.com/sz3/cfc, running with 4 CPU threads on a Qualcomm Snapdragon 625
@@ -26,9 +26,14 @@
 		* cimbar.org uses the `shakycam` option to allow the receiver to detect/discard "in between" frames as part of the scan step. This allows it to spend more processing time decoding real data.
 	* burst rate can be higher (or lower)
 		* to this end, lower ecc settings *can* provide better burst rates
-	* 8-color cimbar is considerably more sensitive to lighting conditions and color tints. When in doubt, fall back to 4-color.
+	* 4-color cimbar is currently preferred, and will give more consistent transfer speeds.
+	* 8-color cimbar should be considered a prototype within a prototype. It is considerably more sensitive to lighting conditions and color tints.
 
 * other notes:
-		* having better lighting in the frame often leads to better results -- this is why cimbar.org has a (mostly) white background. cfc uses android's auto-exposure, auto-focus, etc (it's a very simple app). So good ambient light -- or a white background -- can lead to more consitent quality frame capture.
+		* having better lighting in the frame often leads to better results -- this is why cimbar.org has a (mostly) white background. cfc uses android's auto-exposure, auto-focus, etc (it's a very simple app). Good ambient light -- or a white background -- can lead to more consitent quality frame capture.
+		* because of the lighting/exposure question, I usually "shoot" in landscape instead of portrait.
 		* cfc currently has a low resolution, so the cimbar frame should take up as much of the display as possible (trust the guide brackets)
-		* similarly, it's best to keep the camera angle as straight-on as possible, to decode the whole image successfully. Decodes should still happen at higher angles, but the "smaller" part of the image may have more errors than the error correction can deal with.
+		* similarly, it's best to keep the camera angle straight-on -- instead of at an angle -- to decode the whole image successfully. Decodes should still happen at higher angles, but the "smaller" part of the image may have more errors than the ECC can deal with.
+		* other things to be wary of:
+			* glare from light sources.
+			* shaky hands.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -20,6 +20,7 @@
 	* 4,717,525 bytes in 40s -> 943 kilobits/s (~118 KB/s)
 
 * details:
+	* cimbar has built-in compression using zstd. What's being measured here is bits over the wire, e.g. data after compression is applied.
 	* these numbers are using https://github.com/sz3/cfc, running with 4 CPU threads on a Qualcomm Snapdragon 625
 		* perhaps I will buy a new cell phone to inflate the benchmark numbers.
 	* the sender is the cimbar.org wasm implementation. An equivalent command line is `./cimbar_send /path/to/file -s`

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,22 +9,26 @@
 	* There are 4 or 8 possible colors, encoding an additional 2-3 bits per tile.
 	* These 6-7 bits per tile work out to a maximum of 9300-10850 bytes per barcode, though in practice this number is reduced by error correction.
 	* The default ecc setting is 30/155, which is how we go from 9300 -> 7500 bytes of real data for a 4-color cimbar image.
-		* Reed Solomon is not an ideal for this use case -- specifically, it corrects byte errors, and cimbar errors tend to involve 1-3 bits at a time. However, since Reed Solomon implementations are ubiquitous, I used it for this prototype.
+		* Reed Solomon is not perfect for this use case -- specifically, it corrects byte errors, and cimbar errors tend to involve 1-3 bits at a time. However, since Reed Solomon implementations are ubiquitous, it is currently in use.
 
 ## Current sustained benchmark
 
 * 4-color cimbar with ecc=30:
-	* 2,980,556 bytes (after compression) in 36s -> 662 kilobits/s (~82 KB/s)
+	* 2,980,556 bytes (after compression) in 31s -> 769 kilobits/s (~96 KB/s)
 
 * 8-color cimbar with ecc=30:
-	* 2,980,556 bytes in 31s -> 769 kilobits/s (~96 KB/s)
+	* 2,980,556 bytes in 29s -> 822 kilobits/s (~102 KB/s)
 
 * details:
-	* these numbers are use https://github.com/sz3/cfc, running with 4 CPU threads on a Qualcomm Snapdragon 625
+	* these numbers are using https://github.com/sz3/cfc, running with 4 CPU threads on a Qualcomm Snapdragon 625
 		* perhaps I will buy a new cell phone to inflate the benchmark numbers.
-	* the sender commandline is `./cimbar_send /path/to/file -s`
-		* the `shakycam` option allows cfc to quickly discard ghosted frames, and spend more time decoding real data.
+	* the sender is the cimbar.org wasm implementation. An equivalent command line is `./cimbar_send /path/to/file -s`
+		* cimbar.org uses the `shakycam` option to allow the receiver to detect/discard "in between" frames as part of the scan step. This allows it to spend more processing time decoding real data.
 	* burst rate can be higher (or lower)
 		* to this end, lower ecc settings *can* provide better burst rates
-	* 8-color cimbar is considerably more sensitive to lighting conditions. Notably, decoding has some issues with dim screens.
+	* 8-color cimbar is considerably more sensitive to lighting conditions and color tints. When in doubt, fall back to 4-color.
 
+* other notes:
+		* having better lighting in the frame often leads to better results -- this is why cimbar.org has a (mostly) white background. cfc uses android's auto-exposure, auto-focus, etc (it's a very simple app). So good ambient light -- or a white background -- can lead to more consitent quality frame capture.
+		* cfc currently has a low resolution, so the cimbar frame should take up as much of the display as possible (trust the guide brackets)
+		* similarly, it's best to keep the camera angle as straight-on as possible, to decode the whole image successfully. Decodes should still happen at higher angles, but the "smaller" part of the image may have more errors than the error correction can deal with.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Behold: an experimental barcode format for air-gapped data transfer.
 
-It can sustain speeds of 770+ kilobits/s (~96 KB/s) using nothing but a smartphone camera!
+It can sustain speeds of 943+ kilobits/s (~118 KB/s) using just a computer monitor and a smartphone camera!
 
 ## Explain?
 
@@ -25,7 +25,9 @@ No internet/bluetooth/NFC/etc is used. All data is transmitted through the camer
 
 ## Platforms
 
-The code is written in C++, and developed/tested on amd64+linux, arm64+android, and emscripten+wasm. It probably works, or can be made to work, on other platforms.
+The code is written in C++, and developed/tested on amd64+linux, arm64+android (decoder only), and emscripten+WASM (encoder only). It probably works, or can be made to work, on other platforms.
+
+Crucially, because the encoder compiles to asmjs and wasm, it can run on anything with a modern web browser. There are [releases](https://github.com/sz3/libcimbar/releases/latest) if you wish to run the encoder locally instead of via cimbar.org.
 
 ## Library dependencies
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Behold: an experimental barcode format for air-gapped data transfer.
 
 It can sustain speeds of 943+ kilobits/s (~118 KB/s) using just a computer monitor and a smartphone camera!
 
+![A non-animated cimbar code](https://github.com/sz3/cimbar-samples/blob/v0.5/6bit/4cecc30f.png)
+
 ## Explain?
 
 The encoder outputs an animated barcode to a computer or smartphone screen:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No internet/bluetooth/NFC/etc is used. All data is transmitted through the camer
 
 `cimbar` is a high-density 2D barcode format. Data is stored in a grid of colored tiles -- bits are encoded based on which tile is chosen, and which color is chosen to draw the tile. Reed Solomon error correction is applied on the data, to account for the lossy nature of the video -> digital decoding. Sub-1% error rates are expected, and corrected.
 
-`libcimbar`, this optimized implementation, includes a simple protocol for file encoding based on fountain codes (`wirehair`). Files of up to 33MB can be encoded in a series of cimbar codes, which can be output as images or a live video feed. Once enough distinct image frames have been decoded successfully, the file will be reconstructed successfully. This is true even if the images are received out of order, or if some have been corrupted or are missing.
+`libcimbar`, this optimized implementation, includes a simple protocol for file encoding built on fountain codes (`wirehair`) and zstd compression. Files of up to 33MB (after compression!) are encoded in a series of cimbar codes, which can be output as images or a live video feed. Once enough distinct image frames have been decoded successfully, the file will be reconstructed and decompressed successfully. This is true even if the images are received out of order, or if some have been corrupted or are missing.
 
 ## Platforms
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,9 +31,10 @@ Performance optimizations aside, there are a number of paths that might be inter
 	* a smaller grid would be less information dense, but more resilient to errors. Probably.
 * optimal grid shape?
 	* it's a square because QR codes are square. That's it. Should it be?
+	* I'm strongly considering 4:3 for the next revision
 * more efficient ECC?
-	* LDPC?
-	* Reed Solomon operates on bytes. Most decode errors tend to average out at 1-3 bits. It's not a total disaster, because it works. However, it would be nice to have denser error correction codes.
+	* QC-LDPC?
+	* Reed Solomon operates on bytes. Most decode errors tend to average out at 1-3 bits. In the pathological case, such a bit error will span two bytes. It's not a total disaster, because it works. However, it would be nice to use state of the art ECC.
 * proper GPU support (OpenCV + openCL) on android?
 * ???
 	* still reading? Of course there's more! There's always more!

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ libcimbar is fairly optimized, to achieve the *proof* part of proof-of-concept. 
 Performance optimizations aside, there are a number of paths that might be interesting to pursue. Some I may take a look at, but most I will leave to any enterprising developer who wants to take up the cause:
 
 * proper metadata/header information?
-	* would be nice to be able to determine ecc/#colors/#smybols from the cimbar image itself?
+	* would be nice to be able to determine ecc/#colors/#symbols from the cimbar image itself?
 	* The bottom right corner is the obvious place to reclaim space to make this possible.
 * multi-frame decoding?
 	* when decoding a static cimbar image, it would be useful to be able to use prior (unsuccessful) decode attempts to inform a future decode, and -- hopefully -- increase the probability of success. Currently, all frames are decoded independently.
@@ -16,7 +16,7 @@ Performance optimizations aside, there are a number of paths that might be inter
 * optimal symbol set?
 	* the 16-symbol (4 bit) set is hand-drawn. I stared with ~40 or so hand-drawn symbols, and used the 16 that performed best with each other.
 	* there is surely a more optimal set -- a more rigorous approach should yield lower error rates!
-	* but, more importantly, it may be possible to go up to 32 symbols, and encode 5 bits per tile?
+	* but, more importantly, it may be possible to go up to 32 symbols, and encode 5 symbol bits per tile?
 * optimal symbol size?
 	* the symbols that make up each cell on the cimbar grid are 8x8 (in a 9x9 grid).
 	* this is because imagehash was on 8x8 tiles!
@@ -25,17 +25,24 @@ Performance optimizations aside, there are a number of paths that might be inter
 * optimal color set?
 	* the 4-color (2 bit) pallettes seem reasonable. 8-color, perhaps less so?
 	* this may be a limitation of the algorithm/approach, however. Notably, since each symbol is drawn with one pallette color, all colors need sufficient contrast against the backdrop (#000 or #FFF, depending). This constrains the color space somewhat, and less distinct colors == more errors.
+	* in addition to contrast, there is interplay (that I don't currently understand) between the overall brightness of the image and the exposure time needed for high framerate capture. More clean frames == more troughput.
 * optimal grid size?
 	* 1024x1024 is a remnant of the early prototyping process. There is nothing inherently special about it (except that it fits on a 1920x1080 screen, which seems good)
 		* the tile grid itself is 1008x1008 (1008 == 9x112 -- there are 112 tile rows and columns)
 	* a smaller grid would be less information dense, but more resilient to errors. Probably.
 * optimal grid shape?
 	* it's a square because QR codes are square. That's it. Should it be?
-	* I'm strongly considering 4:3 for the next revision
+	* I'm strongly considering 4:3 for the next revision.
 * more efficient ECC?
 	* QC-LDPC?
-	* Reed Solomon operates on bytes. Most decode errors tend to average out at 1-3 bits. In the pathological case, such a bit error will span two bytes. It's not a total disaster, because it works. However, it would be nice to use state of the art ECC.
+	* Reed Solomon operates on bytes. Most decode errors tend to average out at 1-3 bits. (In the pathological case, a single read error will span two bytes.) It's not a total disaster -- it still works. 
+	* I expect that state of the art ECC will allow 6-15% better throughput.
+		* it's a wide range due to various unknowns (unknowns to me, anyway)
 * proper GPU support (OpenCV + openCL) on android?
+	* It *might* be useful. [CFC]((https://github.com/sz3/cfc) is the current test bed for this.
+* wasm decoder?
+	* probably needs to use Web Workers
+	* in-browser GPGPU support would be interesting (but I'm not counting on it)
 * ???
 	* still reading? Of course there's more! There's always more!
 

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
 	unsigned ecc = cimbar::Config::ecc_bytes();
 	options.add_options()
 	    ("i,in", "Encoded pngs/jpgs/etc (for decode), or file to encode", cxxopts::value<vector<string>>())
-	    ("o,out", "Output file or directory.", cxxopts::value<string>())
+	    ("o,out", "Output file prefix (encoding) or directory (decoding).", cxxopts::value<string>())
 	    ("c,color-bits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
 	    ("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
 	    ("f,fountain", "Attempt fountain encode/decode", cxxopts::value<bool>())

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -60,11 +60,7 @@ int main(int argc, char** argv)
 	bool use_shakycam = result.count("shakycam");
 
 	cimbar::shaky_cam cam(cimbar::Config::image_size(), 1080, 1080, dark);
-	// if we don't need the shakycam, we'll just turn it off
-	// we could use a separate code path (just do a mat copyTo),
-	// but this is fine.
-	if (!use_shakycam)
-		cam.toggle();
+	cam.toggle();
 
 	cimbar::window w(cam.width(), cam.height(), "cimbar_send");
 	if (!w.is_good())
@@ -76,7 +72,7 @@ int main(int argc, char** argv)
 	bool running = true;
 	bool start = true;
 
-	auto draw = [&w, &cam, use_rotatecam, delay, &running, &start] (const cv::Mat& frame, unsigned) {
+	auto draw = [&w, &cam, use_rotatecam, use_shakycam, delay, &running, &start] (const cv::Mat& frame, unsigned) {
 		if (!start and w.should_close())
 			return running = false;
 		start = false;
@@ -85,6 +81,8 @@ int main(int argc, char** argv)
 		w.show(windowImg, delay);
 		if (use_rotatecam)
 			w.rotate();
+		if (use_shakycam)
+			w.shake();
 		return true;
 	};
 

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -58,8 +58,9 @@ int main(int argc, char** argv)
 	bool dark = true;
 	bool use_rotatecam = result.count("rotatecam");
 	bool use_shakycam = result.count("shakycam");
+	int window_size = 1080;
 
-	cimbar::window w(1080, 1080, "cimbar_send");
+	cimbar::window w(window_size, window_size, "cimbar_send");
 	if (!w.is_good())
 	{
 		std::cerr << "failed to create window :(" << std::endl;
@@ -85,6 +86,6 @@ int main(int argc, char** argv)
 	Encoder en(ecc, cimbar::Config::symbol_bits(), colorBits);
 	while (running)
 		for (const string& f : infiles)
-			en.encode_fountain(f, draw, compressionLevel);
+			en.encode_fountain(f, draw, compressionLevel, 8.0, window_size);
 	return 0;
 }

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -59,10 +59,7 @@ int main(int argc, char** argv)
 	bool use_rotatecam = result.count("rotatecam");
 	bool use_shakycam = result.count("shakycam");
 
-	cimbar::shaky_cam cam(cimbar::Config::image_size(), 1080, 1080, dark);
-	cam.toggle();
-
-	cimbar::window w(cam.width(), cam.height(), "cimbar_send");
+	cimbar::window w(1080, 1080, "cimbar_send");
 	if (!w.is_good())
 	{
 		std::cerr << "failed to create window :(" << std::endl;
@@ -72,13 +69,12 @@ int main(int argc, char** argv)
 	bool running = true;
 	bool start = true;
 
-	auto draw = [&w, &cam, use_rotatecam, use_shakycam, delay, &running, &start] (const cv::Mat& frame, unsigned) {
+	auto draw = [&w, use_rotatecam, use_shakycam, delay, &running, &start] (const cv::Mat& frame, unsigned) {
 		if (!start and w.should_close())
 			return running = false;
 		start = false;
 
-		cv::Mat& windowImg = cam.draw(frame);
-		w.show(windowImg, delay);
+		w.show(frame, delay);
 		if (use_rotatecam)
 			w.rotate();
 		if (use_shakycam)

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -55,7 +55,6 @@ int main(int argc, char** argv)
 		fps = defaultFps;
 	unsigned delay = 1000 / fps;
 
-	bool dark = true;
 	bool use_rotatecam = result.count("rotatecam");
 	bool use_shakycam = result.count("shakycam");
 	int window_size = 1080;

--- a/src/lib/cimb_translator/CimbWriter.h
+++ b/src/lib/cimb_translator/CimbWriter.h
@@ -7,7 +7,7 @@
 class CimbWriter
 {
 public:
-	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true);
+	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, int size=0);
 
 	bool write(unsigned bits);
 	bool done() const;
@@ -15,7 +15,11 @@ public:
 	cv::Mat image() const;
 
 protected:
+	void paste(const cv::Mat& img, int x, int y);
+
+protected:
 	cv::Mat _image;
 	CellPositions _positions;
 	CimbEncoder _encoder;
+	unsigned _offset = 0;
 };

--- a/src/lib/cimb_translator/test/CimbWriterTest.cpp
+++ b/src/lib/cimb_translator/test/CimbWriterTest.cpp
@@ -20,5 +20,23 @@ TEST_CASE( "CimbWriterTest/testSimple", "[unit]" )
 	}
 
 	cv::Mat img = cw.image();
+	assertEquals(1024, img.cols);
+	assertEquals(1024, img.rows);
 	assertEquals( 0xeecc8800efce8c08, image_hash::average_hash(img) );
+}
+
+TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
+{
+	CimbWriter cw(4, 2, true, 1040);
+
+	while (1)
+	{
+		if (!cw.write(0))
+			break;
+	}
+
+	cv::Mat img = cw.image();
+	assertEquals(1040, img.cols);
+	assertEquals(1040, img.rows);
+	assertEquals( 0xab00ab02af0abfab, image_hash::average_hash(img) );
 }

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -15,7 +15,7 @@ public:
 	using SimpleEncoder::SimpleEncoder;
 
 	unsigned encode(const std::string& filename, std::string output_prefix);
-	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=6, double redundancy=1.2);
+	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=6, double redundancy=1.2, int canvas_size=0);
 	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=6, double redundancy=4.0, int canvas_size=0);
 };
 
@@ -67,7 +67,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	return i;
 }
 
-inline unsigned Encoder::encode_fountain(const std::string& filename, std::string output_prefix, int compression_level, double redundancy)
+inline unsigned Encoder::encode_fountain(const std::string& filename, std::string output_prefix, int compression_level, double redundancy, int canvas_size)
 {
 	std::function<bool(const cv::Mat&, unsigned)> fun = [output_prefix] (const cv::Mat& frame, unsigned i) {
 		std::string output = fmt::format("{}_{}.png", output_prefix, i);
@@ -75,5 +75,5 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, std::strin
 		cv::cvtColor(frame, bgr, cv::COLOR_RGB2BGR);
 		return cv::imwrite(output, bgr);
 	};
-	return encode_fountain(filename, fun, compression_level, redundancy);
+	return encode_fountain(filename, fun, compression_level, redundancy, canvas_size);
 }

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -16,7 +16,7 @@ public:
 
 	unsigned encode(const std::string& filename, std::string output_prefix);
 	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=6, double redundancy=1.2);
-	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=6, double redundancy=4.0);
+	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=6, double redundancy=4.0, int canvas_size=0);
 };
 
 inline unsigned Encoder::encode(const std::string& filename, std::string output_prefix)
@@ -39,7 +39,7 @@ inline unsigned Encoder::encode(const std::string& filename, std::string output_
 	return i;
 }
 
-inline unsigned Encoder::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy)
+inline unsigned Encoder::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy, int canvas_size)
 {
 	std::ifstream infile(filename);
 	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, compression_level);
@@ -56,7 +56,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	unsigned i = 0;
 	while (i < requiredFrames)
 	{
-		auto frame = encode_next(*fes);
+		auto frame = encode_next(*fes, canvas_size);
 		if (!frame)
 			break;
 

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -33,7 +33,6 @@ TEST_CASE( "EncoderTest/testVanilla", "[unit]" )
 		{
 			std::string path = fmt::format("{}_{}.png", outPrefix, i);
 			cv::Mat img = cv::imread(path);
-			cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 			assertEquals( hashes[i], image_hash::average_hash(img) );
 		}
 	}
@@ -56,7 +55,6 @@ TEST_CASE( "EncoderTest/testFountain", "[unit]" )
 		{
 			std::string path = fmt::format("{}_{}.png", outPrefix, i);
 			cv::Mat img = cv::imread(path);
-			cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 			assertEquals( hashes[i], image_hash::average_hash(img) );
 		}
 	}
@@ -69,13 +67,12 @@ TEST_CASE( "EncoderTest/testFountain.Compress", "[unit]" )
 	std::string inputFile = TestCimbar::getProjectDir() + "/LICENSE";
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
-	Encoder enc(40, 4, 2);
+	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xf8cde200e90582e4;
+	uint64_t hash = 0x4fd34f01ee80a28d;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
-	cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 	assertEquals( hash, image_hash::average_hash(img) );
 }
 
@@ -101,4 +98,22 @@ TEST_CASE( "EncoderTest/testPiecemealFountainEncoder", "[unit]" )
 
 	uint64_t hash = 0xf8cde200e90582e4;
 	assertEquals( hash, image_hash::average_hash(*frame) );
+}
+
+TEST_CASE( "EncoderTest/testFountain.Size", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+
+	std::string inputFile = TestCimbar::getProjectDir() + "/LICENSE";
+	std::string outPrefix = tempdir.path() / "encoder.fountain";
+
+	Encoder enc(30, 4, 2);
+	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 10, 2.0, 1080) );
+
+	uint64_t hash = 0x8985b70d93675786;
+	std::string path = fmt::format("{}_0.png", outPrefix);
+	cv::Mat img = cv::imread(path);
+	assertEquals( 1080, img.rows );
+	assertEquals( 1080, img.cols );
+	assertEquals( hash, image_hash::average_hash(img) );
 }

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -117,8 +117,9 @@ public:
 
 	std::pair<float, float> shake_transform() const
 	{
+		const float step = .007407407f;  // 8 / 1080
 		static constexpr std::array<std::pair<float, float>, 8> SHAKE_POS = {{
-		    {0, 0}, {-.008, -.008}, {0, 0}, {.008, .008}, {0, 0}, {-.008, .008}, {0, 0}, {.008, -.008}
+		    {0, 0}, {-step, -step}, {0, 0}, {step, step}, {0, 0}, {-step, step}, {0, 0}, {step, -step}
 		}};
 		return SHAKE_POS[_shake];
 	}

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -33,7 +33,7 @@ protected:
 	    {0, -1, -1, 0} // right 270
 	}};
 
-	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(float dim)
+	static std::array<std::pair<GLfloat, GLfloat>, 4> computeShakePos(float dim)
 	{
 		float shake = 8.0f / dim; // 1080
 		float zero = 0.0f;
@@ -41,11 +41,7 @@ protected:
 			{zero, zero},
 			{zero-shake, zero-shake},
 			{zero, zero},
-			{zero+shake, zero+shake},
-			{zero, zero},
-			{zero-shake, zero+shake},
-			{zero, zero},
-			{zero+shake, zero-shake}
+			{zero+shake, zero+shake}
 		}};
 	}
 
@@ -176,7 +172,7 @@ protected:
 	unsigned _i = 0;
 	float _dimension;
 
-	std::array<std::pair<GLfloat, GLfloat>, 8> _shakePos;
+	std::array<std::pair<GLfloat, GLfloat>, 4> _shakePos;
 	loop_iterator<decltype(_shakePos)> _shake;
 	loop_iterator<decltype(ROTATIONS)> _rotation;
 };

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -33,10 +33,10 @@ protected:
 	    {0, -1, -1, 0} // right 270
 	}};
 
-	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(float dim)
+	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(float src_dim, float target_dim)
 	{
-		float shake = 8.0f / dim; // 1080
-		float zero = (dim - 1000.0) / (dim*2);
+		float shake = 8.0f / target_dim;
+		float zero = (target_dim - src_dim + 3) / (target_dim*2);
 		return {{
 			{zero, zero},
 			{zero-shake, zero-shake},
@@ -50,10 +50,11 @@ protected:
 	}
 
 public:
-	gl_2d_display(unsigned width, unsigned height)
+	gl_2d_display(unsigned src_dim, unsigned target_dim)
 	    : _p(create())
-	    , _dimension(std::min(width, height))
-	    , _shakePos(computeShakePos(_dimension))
+	    , _srcDim(src_dim)
+	    , _targetDim(target_dim)
+	    , _shakePos(computeShakePos(_srcDim, _targetDim))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{
@@ -90,7 +91,7 @@ public:
 
 		// scaling
 		GLuint scalingUniform = glGetUniformLocation(prog, "scaling");
-		glUniform1f(scalingUniform, 2 * (1008 / _dimension));
+		glUniform1f(scalingUniform, 2 * (_srcDim / _targetDim));
 
 		// pass in rotation matrix
 		GLuint rotateUniform = glGetUniformLocation(prog, "rot");
@@ -179,7 +180,8 @@ protected:
 	std::array<GLuint, 3> _vbo;
 	GLuint _vao;
 	unsigned _i = 0;
-	float _dimension;
+	float _srcDim;
+	float _targetDim;
 
 	std::array<std::pair<GLfloat, GLfloat>, 8> _shakePos;
 	loop_iterator<decltype(_shakePos)> _shake;

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -33,10 +33,10 @@ protected:
 	    {0, -1, -1, 0} // right 270
 	}};
 
-	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(float src_dim, float target_dim)
+	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(float dim)
 	{
-		float shake = 8.0f / target_dim;
-		float zero = (target_dim - src_dim + 3) / (target_dim*2);
+		float shake = 8.0f / dim; // 1080
+		float zero = 0.0f;
 		return {{
 			{zero, zero},
 			{zero-shake, zero-shake},
@@ -50,11 +50,10 @@ protected:
 	}
 
 public:
-	gl_2d_display(unsigned src_dim, unsigned target_dim)
+	gl_2d_display(unsigned width, unsigned height)
 	    : _p(create())
-	    , _srcDim(src_dim)
-	    , _targetDim(target_dim)
-	    , _shakePos(computeShakePos(_srcDim, _targetDim))
+	    , _dimension(std::min(width, height))
+	    , _shakePos(computeShakePos(_dimension))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{
@@ -88,10 +87,6 @@ public:
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture);
 		glUniform1i(textureUniform, 0);
-
-		// scaling
-		GLuint scalingUniform = glGetUniformLocation(prog, "scaling");
-		glUniform1f(scalingUniform, 2 * (_srcDim / _targetDim));
 
 		// pass in rotation matrix
 		GLuint rotateUniform = glGetUniformLocation(prog, "rot");
@@ -150,14 +145,13 @@ protected:
 		static const std::string VERTEX_SHADER_SRC = R"(#version 300 es
 		uniform mat2 rot;
 		uniform vec2 tform;
-		uniform float scaling;
 		in vec4 vert;
 		out vec2 texCoord;
 		void main() {
 		   gl_Position = vec4(vert.x, vert.y, 0.0f, 1.0f);
 		   vec2 ori = vec2(vert.x, vert.y);
 		   ori *= rot;
-		   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / scaling;
+		   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / 2.0;
 		   texCoord -= tform;
 		})";
 
@@ -180,8 +174,7 @@ protected:
 	std::array<GLuint, 3> _vbo;
 	GLuint _vao;
 	unsigned _i = 0;
-	float _srcDim;
-	float _targetDim;
+	float _dimension;
 
 	std::array<std::pair<GLfloat, GLfloat>, 8> _shakePos;
 	loop_iterator<decltype(_shakePos)> _shake;

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -32,10 +32,16 @@ protected:
 	    {0, -1, -1, 0} // right 270
 	}};
 
+	static std::array<std::pair<GLfloat, GLfloat>, 8> computeShakePos(unsigned dim)
+	{
+		float shake = 8.0f / dim;
+		return {{ {0, 0}, {-shake, -shake}, {0, 0}, {shake, shake}, {0, 0}, {-shake, shake}, {0, 0}, {shake, -shake} }};
+	}
+
 public:
-	gl_2d_display(float shake=0)
+	gl_2d_display(unsigned width, unsigned height)
 	    : _p(create())
-	    , _shakePos{{ {0, 0}, {-shake, -shake}, {0, 0}, {shake, shake}, {0, 0}, {-shake, shake}, {0, 0}, {shake, -shake} }}
+	    , _shakePos(computeShakePos(std::min(width, height)))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -7,8 +7,6 @@
 
 #include <GLES3/gl3.h>
 #include <GLES2/gl2ext.h>
-
-#include <iostream>
 #include <memory>
 
 namespace cimbar {
@@ -48,8 +46,7 @@ protected:
 public:
 	gl_2d_display(unsigned width, unsigned height)
 	    : _p(create())
-	    , _dimension(std::min(width, height))
-	    , _shakePos(computeShakePos(_dimension))
+	    , _shakePos(computeShakePos(std::min(width, height)))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{
@@ -170,7 +167,6 @@ protected:
 	std::array<GLuint, 3> _vbo;
 	GLuint _vao;
 	unsigned _i = 0;
-	float _dimension;
 
 	std::array<std::pair<GLfloat, GLfloat>, 4> _shakePos;
 	loop_iterator<decltype(_shakePos)> _shake;

--- a/src/lib/gui/shaky_cam.h
+++ b/src/lib/gui/shaky_cam.h
@@ -9,8 +9,8 @@ namespace cimbar {
 class shaky_cam
 {
 public:
-	static constexpr std::array<std::pair<int, int>, 8> SHAKE_POS = {{
-	    {0, 0}, {-8, -8}, {0, 0}, {8, 8}, {0, 0}, {-8, 8}, {0, 0}, {8, -8}
+	static constexpr std::array<std::pair<int, int>, 4> SHAKE_POS = {{
+	    {0, 0}, {-8, -8}, {0, 0}, {8, 8}
 	}};
 
 public:

--- a/src/lib/gui/shaky_cam.h
+++ b/src/lib/gui/shaky_cam.h
@@ -68,6 +68,7 @@ public:
 		}
 
 		img.copyTo(_frame(cv::Rect(offsetX, offsetY, img.cols, img.rows)));
+		cv::cvtColor(_frame, _frame, cv::COLOR_BGR2RGB);
 		return _frame;
 	}
 

--- a/src/lib/gui/shaky_cam.h
+++ b/src/lib/gui/shaky_cam.h
@@ -10,13 +10,13 @@ class shaky_cam
 {
 public:
 	static constexpr std::array<std::pair<int, int>, 8> SHAKE_POS = {{
-		{0, 0}, {-8, -8}, {0, 0}, {8, 8}, {0, 0}, {-8, 8}, {0, 0}, {8, -8}
+	    {0, 0}, {-8, -8}, {0, 0}, {8, 8}, {0, 0}, {-8, 8}, {0, 0}, {8, -8}
 	}};
 
 public:
 	shaky_cam(unsigned img_size, unsigned w, unsigned h, bool dark)
-		: _shakycam(true)
-		, _shakePos(SHAKE_POS)
+	    : _shakycam(true)
+	    , _shakePos(SHAKE_POS)
 	{
 		unsigned minFrameSize = img_size + 16;
 		w = std::max(w, minFrameSize);
@@ -45,6 +45,12 @@ public:
 		_shakePos.reset();
 	}
 
+	void shake()
+	{
+		if (_shakycam)
+			++_shakePos;
+	}
+
 	cv::Mat& draw(const cv::Mat& img)
 	{
 		_frame = _bgcolor;
@@ -59,7 +65,6 @@ public:
 				offsetX += (*_shakePos).first;
 				offsetY += (*_shakePos).second;
 			}
-			++_shakePos;
 		}
 
 		img.copyTo(_frame(cv::Rect(offsetX, offsetY, img.cols, img.rows)));

--- a/src/lib/gui/window_cvhighgui.h
+++ b/src/lib/gui/window_cvhighgui.h
@@ -3,12 +3,16 @@
 
 #include "window_interface.h"
 
+#include "shaky_cam.h"
+
 namespace cimbar {
 
 class window_cvhighgui : public window_interface<window_cvhighgui>
 {
 public:
-	window_cvhighgui(unsigned, unsigned, std::string)
+	window_cvhighgui(unsigned width, unsigned height, std::string title)
+	    : _cam(std::min(width, height), width, height, true)
+	    , _title(title)
 	{}
 
 	bool is_good() const
@@ -18,20 +22,28 @@ public:
 
 	bool should_close() const
 	{
-		return cv::getWindowProperty("image", cv::WND_PROP_AUTOSIZE) < 0;
+		return cv::getWindowProperty(_title, cv::WND_PROP_AUTOSIZE) < 0;
 	}
 
 	void rotate(unsigned i=1)
 	{
 	}
 
+	void shake(unsigned i=1)
+	{
+		if (i > 0)
+			_cam.shake();
+	}
+
 	void show(const cv::Mat& img, unsigned delay)
 	{
-		cv::imshow("image", img);
+		cv::imshow(_title, _cam.draw(img));
 		cv::waitKey(delay); // functions as the frame delay... you can hold down a key to make it go faster
 	}
 
 protected:
+	cimbar::shaky_cam _cam;
+	std::string _title;
 };
 
 }

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -32,8 +32,7 @@ public:
 		glfwMakeContextCurrent(_w);
 		glfwSwapInterval(1);
 
-		float shake = 8.0 / std::min(width, height);
-		_display = std::make_shared<cimbar::gl_2d_display>(shake);
+		_display = std::make_shared<cimbar::gl_2d_display>(width, height);
 		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -30,6 +30,7 @@ public:
 			return;
 		}
 		glfwMakeContextCurrent(_w);
+		glfwSwapInterval(1);
 
 		_display = std::make_shared<cimbar::gl_2d_display>();
 		glGenTextures(1, &_texid);

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -16,6 +16,7 @@ class window_glfw : public window_interface<window_glfw>
 {
 public:
 	window_glfw(unsigned width, unsigned height, std::string title)
+	    : _width(width)
 	{
 		if (!glfwInit())
 		{
@@ -32,7 +33,7 @@ public:
 		glfwMakeContextCurrent(_w);
 		glfwSwapInterval(1);
 
-		_display = std::make_shared<cimbar::gl_2d_display>(1024, std::min(width, height));
+		_display = std::make_shared<cimbar::gl_2d_display>(width, height);
 		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}
@@ -95,6 +96,11 @@ public:
 			std::this_thread::sleep_for(std::chrono::milliseconds(delay-millis));
 	}
 
+	unsigned width() const
+	{
+		return _width;
+	}
+
 protected:
 	void init_opengl(int width, int height)
 	{
@@ -117,8 +123,8 @@ protected:
 	GLFWwindow* _w;
 	GLuint _texid;
 	std::shared_ptr<cimbar::gl_2d_display> _display;
+	unsigned _width;
 	bool _good = true;
 };
 
 }
-

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -61,6 +61,12 @@ public:
 			_display->rotate(i);
 	}
 
+	void shake(unsigned i=1)
+	{
+		if (_display)
+			_display->shake(i);
+	}
+
 	void clear()
 	{
 		if (_display)

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -32,7 +32,8 @@ public:
 		glfwMakeContextCurrent(_w);
 		glfwSwapInterval(1);
 
-		_display = std::make_shared<cimbar::gl_2d_display>();
+		float shake = 8.0 / std::min(width, height);
+		_display = std::make_shared<cimbar::gl_2d_display>(shake);
 		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -32,7 +32,7 @@ public:
 		glfwMakeContextCurrent(_w);
 		glfwSwapInterval(1);
 
-		_display = std::make_shared<cimbar::gl_2d_display>(width, height);
+		_display = std::make_shared<cimbar::gl_2d_display>(1024, std::min(width, height));
 		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}

--- a/src/lib/gui/window_interface.h
+++ b/src/lib/gui/window_interface.h
@@ -27,6 +27,11 @@ struct window_interface
 	{
 		static_cast<T*>(this)->show(img, delay);
 	}
+
+	unsigned width() const
+	{
+		return static_cast<T*>(this)->width();
+	}
 };
 
 }

--- a/src/lib/gui/window_interface.h
+++ b/src/lib/gui/window_interface.h
@@ -27,11 +27,6 @@ struct window_interface
 	{
 		static_cast<T*>(this)->show(img, delay);
 	}
-
-	unsigned width() const
-	{
-		return static_cast<T*>(this)->width();
-	}
 };
 
 }

--- a/src/wasm/cimbar_js/CMakeLists.txt
+++ b/src/wasm/cimbar_js/CMakeLists.txt
@@ -47,7 +47,7 @@ set (LINK_WASM_LIST
 	-s USE_GLFW=3
 	-s FILESYSTEM=0
 	-s TOTAL_MEMORY=134217728
-	-s EXPORTED_FUNCTIONS='["_render","_initialize_GL","_encode","_configure"]'
+	-s EXPORTED_FUNCTIONS='["_render","_next_frame","_initialize_GL","_encode","_configure"]'
 )
 string(REPLACE ";" " " LINK_WASM_FLAGS "${LINK_WASM_LIST}")
 

--- a/src/wasm/cimbar_js/wasm.cpp
+++ b/src/wasm/cimbar_js/wasm.cpp
@@ -51,7 +51,7 @@ int render()
 	if (_fes->block_count() > required)
 	{
 		_fes->reset();
-		_window->rotate(0);
+		_window->shake(0);
 	}
 
 	SimpleEncoder enc(_ecc, cimbar::Config::symbol_bits(), _colorBits);
@@ -102,7 +102,7 @@ int configure(unsigned color_bits)
 				_fes = nullptr;
 				_window->clear();
 			}
-			_window->rotate(0);
+			_window->shake(0);
 		}
 	}
 	return 0;

--- a/src/wasm/cimbar_js/wasm.cpp
+++ b/src/wasm/cimbar_js/wasm.cpp
@@ -44,10 +44,10 @@ int render()
 	if (!_window or !_fes)
 		return 0;
 
-	// we generate 2x the amount of required blocks -- unless everything fits in a single frame.
+	// we generate 8x the amount of required blocks -- unless everything fits in a single frame.
 	unsigned required = _fes->blocks_required();
 	if (required > cimbar::Config::fountain_chunks_per_frame())
-		required = required*4;
+		required = required*8;
 	if (_fes->block_count() > required)
 	{
 		_fes->reset();
@@ -57,7 +57,7 @@ int render()
 	SimpleEncoder enc(_ecc, cimbar::Config::symbol_bits(), _colorBits);
 	enc.set_encode_id(_encodeId);
 
-	std::optional<cv::Mat> img = enc.encode_next(*_fes);
+	std::optional<cv::Mat> img = enc.encode_next(*_fes, _window->width());
 	if (!img)
 	{
 		std::cerr << "no image :(" << std::endl;

--- a/src/wasm/cimbar_js/wasm.cpp
+++ b/src/wasm/cimbar_js/wasm.cpp
@@ -65,7 +65,7 @@ int render()
 	}
 
 	_window->show(*img, 0);
-	_window->rotate();
+	_window->shake();
 	return ++_renders;
 }
 

--- a/src/wasm/cimbar_js/wasm.cpp
+++ b/src/wasm/cimbar_js/wasm.cpp
@@ -41,12 +41,14 @@ int initialize_GL(int width, int height)
 	return 1;
 }
 
+// render() and next_frame() could be put in the same function,
+// but it seems cleaner to split them.
+// in any case, we're concerned with frame pacing (some encodes take longer than others)
 int render()
 {
 	if (!_window or !_fes)
 		return 0;
 
-	// render frame first to minimize frame pacing issues
 	if (_next)
 	{
 		_window->show(*_next, 0);

--- a/src/wasm/cimbar_js/wasm.cpp
+++ b/src/wasm/cimbar_js/wasm.cpp
@@ -17,7 +17,7 @@ namespace {
 	std::shared_ptr<fountain_encoder_stream> _fes;
 	std::optional<cv::Mat> _next;
 
-	int _renders = 0;
+	int _numFrames = 0;
 	uint8_t _encodeId = 0;
 
 	// settings
@@ -51,7 +51,15 @@ int render()
 	{
 		_window->show(*_next, 0);
 		_window->shake();
+		return 1;
 	}
+	return 0;
+}
+
+int next_frame()
+{
+	if (!_window or !_fes)
+		return 0;
 
 	// we generate 8x the amount of required blocks -- unless everything fits in a single frame.
 	unsigned required = _fes->blocks_required();
@@ -67,7 +75,7 @@ int render()
 	enc.set_encode_id(_encodeId);
 
 	_next = enc.encode_next(*_fes, _window->width());
-	return ++_renders;
+	return ++_numFrames;
 }
 
 int encode(uint8_t* buffer, size_t size)

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,9 @@ body {
 	opacity: 0;
 	pointer-events: auto;
 }
+#invisible_click.active {
+	cursor: none;
+}
 #nav-container:focus-within + #invisible_click {
 	pointer-events: none;
 	display: none;

--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,7 @@ body {
 	margin: 0 auto;
 	z-index: -1;
 	color: #F0F0F0;
-	outline: 10px solid black;
+	outline: 8px solid black;
 }
 
 #dragdrop::before {

--- a/web/index.html
+++ b/web/index.html
@@ -272,6 +272,7 @@ body {
       <span id="current-file">No file selected</span>
       <ul>
         <li><a class="attention" id="nav-find-file-link" href="javascript:void(0)" onclick="Main.clickFileInput()">Find File</a></li>
+        <li><a href="javascript:void(0)" onclick="Main.toggleFullscreen()">Fullscreen</a></li>
         <hr>
         <li><a class="c4" href="javascript:void(0)" onclick="Main.setColorBits(2)">4-color</a></li>
         <li><a class="c8" href="javascript:void(0)" onclick="Main.setColorBits(3)">8-color</a></li>

--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,7 @@
 
 body {
 	background-color: white;
-	background-image: linear-gradient(187deg, rgba(16,16,16, 0.07) 0%, rgba(16,16,16, 0.07) 50%,rgba(246,239,239, 0.07) 50%, rgba(246,239,239, 0.07) 100%),linear-gradient(255deg, rgba(255,255,255, 0.09) 0%, rgba(255,255,255, 0.09) 50%,rgba(209,186,186, 0.09) 50%, rgba(209,186,186, 0.09) 100%),linear-gradient(191deg, rgba(170,156,156, 0.08) 0%, rgba(170,156,156, 0.08) 50%,rgba(255,255,255, 0.08) 50%, rgba(255,255,255, 0.08) 100%),linear-gradient(339deg, rgba(255,255,255, 0.04) 0%, rgba(255,255,255, 0.04) 50%,rgba(76,189,219, 0.04) 50%, rgba(76,189,219, 0.04) 100%),linear-gradient(173deg, rgba(125,119,119, 0.09) 0%, rgba(125,119,119, 0.09) 50%,rgba(250,246,246, 0.09) 50%, rgba(250,246,246, 0.09) 100%),linear-gradient(317deg, rgba(255,255,255, 0.01) 0%, rgba(255,255,255, 0.01) 50%,rgba(249,249,249, 0.01) 50%, rgba(249,249,249, 0.01) 100%),linear-gradient(173deg, rgba(138,123,123, 0.07) 0%, rgba(138,123,123, 0.07) 50%,rgba(251,251,251, 0.07) 50%, rgba(251,251,251, 0.07) 100%),linear-gradient(222deg, rgba(243,243,243, 0.05) 0%, rgba(243,243,243, 0.05) 50%,rgba(35,31,31, 0.05) 50%, rgba(35,31,31, 0.05) 100%),linear-gradient(232deg, rgba(251,246,246, 0.01) 0%, rgba(251,246,246, 0.01) 50%,rgba(249,249,249, 0.01) 50%, rgba(249,249,249, 0.01) 100%),linear-gradient(90deg, rgb(0,0,0),rgb(255,255,255),rgb(255,255,255));
+	background-image: radial-gradient(circle at top left, rgb(7,0,0),rgb(244,244,244),rgb(255,255,255));
 	color: gray;
 	height: 100vh;
 	display: grid;
@@ -115,7 +115,7 @@ body {
   pointer-events: auto;
   touch-action: manipulation;
   outline: 0;
-  background-image: linear-gradient(180deg, rgb(0,0,0,0) 20%, rgb(0,0,0) 40%, rgb(0,0,0) 60%, rgb(0,0,0,0) 80%);
+  background-image: linear-gradient(180deg, rgb(0,0,0,0) 10%, rgb(0,0,0) 40%, rgb(0,0,0) 60%, rgb(0,0,0,0) 90%);
 }
 .icon-bar {
   display: block;

--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,8 @@ body {
 	margin: 0 auto;
 	z-index: -1;
 	color: #F0F0F0;
-	outline: 8px solid black;
+	outline: 6px solid black;
+	box-shadow: 0px 0px 12px black, 0px 0px 18px black;
 }
 
 #dragdrop::before {

--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,8 @@
 }
 
 body {
-	background-color: black;
+	background-color: white;
+	background-image: linear-gradient(187deg, rgba(16,16,16, 0.07) 0%, rgba(16,16,16, 0.07) 50%,rgba(246,239,239, 0.07) 50%, rgba(246,239,239, 0.07) 100%),linear-gradient(255deg, rgba(255,255,255, 0.09) 0%, rgba(255,255,255, 0.09) 50%,rgba(209,186,186, 0.09) 50%, rgba(209,186,186, 0.09) 100%),linear-gradient(191deg, rgba(170,156,156, 0.08) 0%, rgba(170,156,156, 0.08) 50%,rgba(255,255,255, 0.08) 50%, rgba(255,255,255, 0.08) 100%),linear-gradient(339deg, rgba(255,255,255, 0.04) 0%, rgba(255,255,255, 0.04) 50%,rgba(76,189,219, 0.04) 50%, rgba(76,189,219, 0.04) 100%),linear-gradient(173deg, rgba(125,119,119, 0.09) 0%, rgba(125,119,119, 0.09) 50%,rgba(250,246,246, 0.09) 50%, rgba(250,246,246, 0.09) 100%),linear-gradient(317deg, rgba(255,255,255, 0.01) 0%, rgba(255,255,255, 0.01) 50%,rgba(249,249,249, 0.01) 50%, rgba(249,249,249, 0.01) 100%),linear-gradient(173deg, rgba(138,123,123, 0.07) 0%, rgba(138,123,123, 0.07) 50%,rgba(251,251,251, 0.07) 50%, rgba(251,251,251, 0.07) 100%),linear-gradient(222deg, rgba(243,243,243, 0.05) 0%, rgba(243,243,243, 0.05) 50%,rgba(35,31,31, 0.05) 50%, rgba(35,31,31, 0.05) 100%),linear-gradient(232deg, rgba(251,246,246, 0.01) 0%, rgba(251,246,246, 0.01) 50%,rgba(249,249,249, 0.01) 50%, rgba(249,249,249, 0.01) 100%),linear-gradient(90deg, rgb(0,0,0),rgb(255,255,255),rgb(255,255,255));
 	color: gray;
 	height: 100vh;
 	display: grid;
@@ -39,6 +40,7 @@ body {
 	margin: 0 auto;
 	z-index: -1;
 	color: #F0F0F0;
+	outline: 10px solid black;
 }
 
 #dragdrop::before {
@@ -113,6 +115,7 @@ body {
   pointer-events: auto;
   touch-action: manipulation;
   outline: 0;
+  background-image: linear-gradient(180deg, rgb(0,0,0,0) 20%, rgb(0,0,0) 40%, rgb(0,0,0) 60%, rgb(0,0,0,0) 80%);
 }
 .icon-bar {
   display: block;
@@ -276,7 +279,7 @@ body {
       </ul>
     </div>
 </div>
-<a id="invisible_click" href="javascript:void(0)" onclick="Main.clickNav()"></a>
+<a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
 
 <script type="text/javascript">
 	// reset zoom

--- a/web/main.js
+++ b/web/main.js
@@ -110,7 +110,8 @@ return {
   nextFrame : function()
   {
     var start = performance.now();
-    var renderCount = Module._render();
+    Module._render();
+    var frameCount = Module._next_frame();
 
     var elapsed = performance.now() - start;
     var nextInterval = _interval>elapsed? _interval-elapsed : 0;
@@ -118,7 +119,7 @@ return {
 
     if (_showStats && renderCount) {
       _renderTime += elapsed;
-      Main.setHTML( "status", elapsed + " : " + renderCount + " : " + Math.ceil(_renderTime/renderCount));
+      Main.setHTML( "status", elapsed + " : " + frameCount + " : " + Math.ceil(_renderTime/frameCount));
     }
   },
 

--- a/web/main.js
+++ b/web/main.js
@@ -68,6 +68,7 @@ return {
     var res = Module._encode(data.byteOffset, data.length);
     console.log(res);
     Main.setTitle(filename);
+    Main.setActive(true);
   },
 
   dragDrop : function(event)
@@ -119,6 +120,14 @@ return {
       _renderTime += elapsed;
       Main.setHTML( "status", elapsed + " : " + renderCount + " : " + Math.ceil(_renderTime/renderCount));
     }
+  },
+
+  setActive : function(active)
+  {
+    // hide cursor when there's a barcode active
+    var invisi = document.getElementById("invisible_click");
+    invisi.classList.remove("active");
+    invisi.classList.add("active");
   },
 
   setColorBits : function(color_bits)

--- a/web/main.js
+++ b/web/main.js
@@ -33,7 +33,7 @@ return {
   {
     console.log("init for canvas " + canvas);
 
-    Module._initialize_GL(1024, 1024);
+    Module._initialize_GL(1040, 1040);
     Main.scaleCanvas(canvas, width, height);
     Main.alignInvisibleClick(canvas);
   },
@@ -45,8 +45,8 @@ return {
       dim = height;
     }
     console.log(dim);
-    if (dim > 1024) {
-      dim = 1024;
+    if (dim > 1040) {
+      dim = 1040;
     }
     canvas.style.width = dim + "px";
     canvas.style.height = dim + "px";

--- a/web/main.js
+++ b/web/main.js
@@ -6,6 +6,17 @@ var _showStats = false;
 var _renders = 0;
 var _renderTime = 0;
 
+function toggleFullscreen()
+{
+  var elem = document.body;
+  if (document.fullscreenElement) {
+    document.exitFullscreen();
+  }
+  else {
+    elem.requestFullscreen();
+  }
+}
+
 function importFile(f)
 {
   const fileReader = new FileReader();
@@ -36,6 +47,11 @@ return {
     Module._initialize_GL(1040, 1040);
     Main.scaleCanvas(canvas, width, height);
     Main.alignInvisibleClick(canvas);
+  },
+
+  toggleFullscreen : function()
+  {
+    toggleFullscreen();
   },
 
   scaleCanvas : function(canvas, width, height)

--- a/web/main.js
+++ b/web/main.js
@@ -8,12 +8,11 @@ var _renderTime = 0;
 
 function toggleFullscreen()
 {
-  var elem = document.body;
   if (document.fullscreenElement) {
     document.exitFullscreen();
   }
   else {
-    elem.requestFullscreen();
+    document.documentElement.requestFullscreen();
   }
 }
 


### PR DESCRIPTION
* switched cimbar.js to the "shaky cam" animation to allow quicker detection (and rejection) of in-between frames by the decoder
   * rotate wasn't cutting it. A lot of CPU cycles were getting burned trying to decode unusable input images.
* since it's now the default, I improved the shaky cam animation to be a bit less visually jarring (humans have to look at it too, not just the computer)
* added a mostly-white background to cimbar.js/.org to help auto-exposure behavior
   * it's silly how much this helps -- it emphasizes that there are likely plenty of performance wins that would come from writing a better android app than cfc
* improved frame-pacing of cimbar.js
   * probably need to port the improvement `cimbar_send` at some point
* added full screen menu option to cimbar.js

The result of the frame pacing fix + auto-exposure jedi-mind-trick is some new benchmark numbers:
* 943+ kilobits/s (~118 KB/s) for 8-color cimbar.
* 838+ kilobits/s (~104 KB/s) for 4-color cimbar.

![the visual embodiment of excitement](https://user-images.githubusercontent.com/5728104/110124426-b07d7100-7d87-11eb-9849-4604bbe6fae4.gif)

https://github.com/sz3/libcimbar/blob/2800ed433f8133312e0b188df47e2931aedf32d5/README.md
