### PR TITLE
Minor tweak to the decode's preprocessing "sharpen"

### DIFF
--- a/WASM.md
+++ b/WASM.md
@@ -22,7 +22,7 @@ mkdir build-wasm
 cd build-wasm
 source /path/to/emscripten/emsdk/emsdk_env.sh
 emcmake cmake .. -DUSE_WASM=1 -DOPENCV_DIR=/path/to/opencv
-emcmake make -j7 install
+make -j7 install
 ```
 
 (do `-DUSE_WASM=2` to use asm.js instead of wasm)

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -30,15 +30,12 @@ namespace {
 		int blockSize = 3; // default: no preprocessing
 
 		cv::Mat symbols;
+		cv::cvtColor(img, symbols, cv::COLOR_RGB2GRAY);
 		if (needs_sharpen)
 		{
-			sharpenSymbolGrid(img, symbols);
-			cv::cvtColor(symbols, symbols, cv::COLOR_RGB2GRAY);
+			sharpenSymbolGrid(symbols, symbols);
 			blockSize = 7;
 		}
-		else
-			cv::cvtColor(img, symbols, cv::COLOR_RGB2GRAY);
-
 		cv::adaptiveThreshold(symbols, symbols, 255, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, blockSize, 0);
 
 		bitbuffer bb(1024*128);


### PR DESCRIPTION
rationale:
1. we're treating RGB as BGR -- per channel operations feel suspicious
2. less data to iterate over
3. seems fine on the test datasets
4. we're trying to sharpen monochrome symbols -- conceptually, color shouldn't be incredibly important

(the reasoning for 1 and 4 is somewhat at odds. In some sense the idea reduces to, "it's simpler this way")