### PR TITLE
Bugfix + `cimbar_recv`, a test decoder app + ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(PROJECTS
 
 	src/exe/cimbar
 	src/exe/cimbar_extract
+	src/exe/cimbar_recv
 	src/exe/cimbar_send
 	src/exe/build_image_assets
 )

--- a/src/exe/cimbar_recv/CMakeLists.txt
+++ b/src/exe/cimbar_recv/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(cimbar_recv)
+
+set (SOURCES
+	recv.cpp
+)
+
+add_executable (
+	cimbar_recv
+	${SOURCES}
+)
+
+target_link_libraries(cimbar_recv
+
+	cimb_translator
+	extractor
+
+	correct_static
+	wirehair
+	zstd
+
+	GL
+	glfw
+	${OPENCV_LIBS}
+	opencv_videoio
+)
+
+add_custom_command(
+	TARGET cimbar_recv POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv> cimbar_recv.dbg
+	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv>
+)
+
+install(
+	TARGETS cimbar_recv
+	DESTINATION bin
+)
+

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -1,0 +1,152 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "cimb_translator/Config.h"
+#include "compression/zstd_decompressor.h"
+#include "encoder/Decoder.h"
+#include "extractor/Extractor.h"
+#include "fountain/fountain_decoder_sink.h"
+#include "gui/window_glfw.h"
+
+#include "cxxopts/cxxopts.hpp"
+#include "serialize/str.h"
+#include "util/File.h"
+#include <opencv2/videoio.hpp>
+#include <GLFW/glfw3.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+using std::string;
+using std::vector;
+
+namespace {
+
+	template <typename TP>
+	TP wait_for_frame_time(unsigned delay, const TP& start)
+	{
+		unsigned millis = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count();
+		if (delay > millis)
+			std::this_thread::sleep_for(std::chrono::milliseconds(delay-millis));
+		return std::chrono::high_resolution_clock::now();
+	}
+
+
+	std::pair<int, int> window_size()
+	{
+		GLFWmonitor* mon = glfwGetPrimaryMonitor();
+		const GLFWvidmode* mode = glfwGetVideoMode(mon);
+		return {mode->width, mode->height};
+	}
+}
+
+
+int main(int argc, char** argv)
+{
+	cxxopts::Options options("cimbar video decoder", "Use the camera to decode data!");
+
+	unsigned colorBits = cimbar::Config::color_bits();
+	unsigned ecc = cimbar::Config::ecc_bytes();
+	unsigned defaultFps = 15;
+	options.add_options()
+		("i,in", "Video source.", cxxopts::value<string>())
+		("o,out", "Output directory (decoding).", cxxopts::value<string>())
+	    ("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
+		("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
+		("f,fps", "Target FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
+	    ("h,help", "Print usage")
+	;
+	options.show_positional_help();
+	options.parse_positional({"in", "out"});
+	options.positional_help("<in> <out>");
+
+	auto result = options.parse(argc, argv);
+	if (result.count("help") or !result.count("in") or !result.count("out"))
+	{
+	  std::cout << options.help() << std::endl;
+	  return 0;
+	}
+
+	string source = result["in"].as<string>();
+	string outpath = result["out"].as<string>();
+
+	colorBits = std::min(3, result["colorbits"].as<int>());
+	ecc = result["ecc"].as<unsigned>();
+	unsigned fps = result["fps"].as<unsigned>();
+	if (fps == 0)
+		fps = defaultFps;
+	unsigned delay = 1000 / fps;
+
+	cv::VideoCapture vc(source.c_str());
+	if (!vc.isOpened())
+	{
+		std::cerr << "failed to open video device :(" << std::endl;
+		return 70;
+	}
+
+	vc.set(cv::CAP_PROP_FRAME_WIDTH, 1920);
+	vc.set(cv::CAP_PROP_FRAME_HEIGHT, 1080);
+
+	//auto [width, height] = window_size();
+	int width = 1280;
+	int height = 1080;
+	std::cout << "got dimensions " << width << "," << height << std::endl;
+
+	cimbar::window_glfw window(width, height, "cimbar_recv");
+	if (!window.is_good())
+	{
+		std::cerr << "failed to create window :(" << std::endl;
+		return 70;
+	}
+
+	Decoder dec;
+
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc);
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> sink(outpath, chunkSize);
+
+	cv::Mat mat;
+
+	std::chrono::time_point start = std::chrono::high_resolution_clock::now();
+	while (true)
+	{
+		// delay, then try to read frame
+		start = wait_for_frame_time(delay, start);
+
+		if (!vc.read(mat))
+		{
+			std::cerr << "failed to read from cam" << std::endl;
+			continue;
+		}
+
+		cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
+
+		// draw some stats on mat?
+		window.show(mat, 0);
+		if (window.should_close())
+			break;
+
+		// extract
+		cv::UMat img = mat.getUMat(cv::ACCESS_RW);
+
+		bool shouldPreprocess = false;
+		Extractor ext;
+		int res = ext.extract(img, img);
+		if (!res)
+		{
+			std::cerr << "no extract " << mat.cols << "," << mat.rows << std::endl;
+			continue;
+		}
+		else if (res == Extractor::NEEDS_SHARPEN)
+			shouldPreprocess = true;
+
+		//cv::imwrite("/tmp/foo-base.png", mat);
+		//cv::imwrite("/tmp/foo-ex.png", img);
+
+		// decode
+		int bytes = dec.decode_fountain(img, sink, shouldPreprocess);
+		std::cerr << "got some bytes " << bytes << std::endl;
+
+	}
+
+	return 0;
+}

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -78,10 +78,11 @@ int main(int argc, char** argv)
 	}
 	vc.set(cv::CAP_PROP_FRAME_WIDTH, 1920);
 	vc.set(cv::CAP_PROP_FRAME_HEIGHT, 1200);
+	vc.set(cv::CAP_PROP_FPS, 60);
 
 	// set max camera res, and use aspect ratio for window size...
 
-	std::cout << fmt::format("width: {}, height {}", vc.get(cv::CAP_PROP_FRAME_WIDTH), vc.get(cv::CAP_PROP_FRAME_HEIGHT)) << std::endl;
+	std::cout << fmt::format("width: {}, height {}, exposure {}", vc.get(cv::CAP_PROP_FRAME_WIDTH), vc.get(cv::CAP_PROP_FRAME_HEIGHT), vc.get(cv::CAP_PROP_EXPOSURE)) << std::endl;
 
 	double ratio = vc.get(cv::CAP_PROP_FRAME_WIDTH) / vc.get(cv::CAP_PROP_FRAME_HEIGHT);
 	int height = 600;

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
 	vc.set(cv::CAP_PROP_FRAME_HEIGHT, 1080);
 
 	//auto [width, height] = window_size();
-	int width = 1280;
+	int width = 1920;
 	int height = 1080;
 	std::cout << "got dimensions " << width << "," << height << std::endl;
 
@@ -99,6 +99,7 @@ int main(int argc, char** argv)
 		return 70;
 	}
 
+	Extractor ext;
 	Decoder dec;
 
 	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc);
@@ -111,25 +112,23 @@ int main(int argc, char** argv)
 	{
 		// delay, then try to read frame
 		start = wait_for_frame_time(delay, start);
+		if (window.should_close())
+			break;
 
 		if (!vc.read(mat))
 		{
 			std::cerr << "failed to read from cam" << std::endl;
 			continue;
 		}
+		cv::UMat img = mat.getUMat(cv::ACCESS_RW);
 
 		cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
 
 		// draw some stats on mat?
 		window.show(mat, 0);
-		if (window.should_close())
-			break;
 
 		// extract
-		cv::UMat img = mat.getUMat(cv::ACCESS_RW);
-
-		bool shouldPreprocess = false;
-		Extractor ext;
+		bool shouldPreprocess = true;
 		int res = ext.extract(img, img);
 		if (!res)
 		{
@@ -139,8 +138,8 @@ int main(int argc, char** argv)
 		else if (res == Extractor::NEEDS_SHARPEN)
 			shouldPreprocess = true;
 
-		//cv::imwrite("/tmp/foo-base.png", mat);
-		//cv::imwrite("/tmp/foo-ex.png", img);
+		cv::imwrite("/tmp/foo-base.png", mat);
+		cv::imwrite("/tmp/foo-ex.png", img);
 
 		// decode
 		int bytes = dec.decode_fountain(img, sink, shouldPreprocess);

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -8,7 +8,6 @@
 
 #include "cxxopts/cxxopts.hpp"
 #include "serialize/str.h"
-#include "util/File.h"
 
 #include <GLFW/glfw3.h>
 #include <opencv2/videoio.hpp>
@@ -17,9 +16,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
-#include <vector>
 using std::string;
-using std::vector;
 
 namespace {
 

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -9,8 +9,9 @@
 #include "cxxopts/cxxopts.hpp"
 #include "serialize/str.h"
 #include "util/File.h"
-#include <opencv2/videoio.hpp>
+
 #include <GLFW/glfw3.h>
+#include <opencv2/videoio.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -107,9 +108,12 @@ int main(int argc, char** argv)
 
 	cv::Mat mat;
 
+	unsigned count = 0;
 	std::chrono::time_point start = std::chrono::high_resolution_clock::now();
 	while (true)
 	{
+		++count;
+
 		// delay, then try to read frame
 		start = wait_for_frame_time(delay, start);
 		if (window.should_close())
@@ -120,8 +124,8 @@ int main(int argc, char** argv)
 			std::cerr << "failed to read from cam" << std::endl;
 			continue;
 		}
-		cv::UMat img = mat.getUMat(cv::ACCESS_RW);
 
+		cv::UMat img = mat.getUMat(cv::ACCESS_RW);
 		cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
 
 		// draw some stats on mat?
@@ -137,9 +141,6 @@ int main(int argc, char** argv)
 		}
 		else if (res == Extractor::NEEDS_SHARPEN)
 			shouldPreprocess = true;
-
-		cv::imwrite("/tmp/foo-base.png", mat);
-		cv::imwrite("/tmp/foo-ex.png", img);
 
 		// decode
 		int bytes = dec.decode_fountain(img, sink, shouldPreprocess);

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -37,13 +37,13 @@ int main(int argc, char** argv)
 
 	unsigned colorBits = cimbar::Config::color_bits();
 	unsigned ecc = cimbar::Config::ecc_bytes();
-	unsigned defaultFps = 15;
+	unsigned defaultFps = 60;
 	options.add_options()
 		("i,in", "Video source.", cxxopts::value<string>())
 		("o,out", "Output directory (decoding).", cxxopts::value<string>())
 	    ("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
 		("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
-		("f,fps", "Target FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
+		("f,fps", "Target decode FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
 	    ("h,help", "Print usage")
 	;
 	options.show_positional_help();
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
 	}
 	vc.set(cv::CAP_PROP_FRAME_WIDTH, 1920);
 	vc.set(cv::CAP_PROP_FRAME_HEIGHT, 1200);
-	vc.set(cv::CAP_PROP_FPS, 60);
+	vc.set(cv::CAP_PROP_FPS, fps);
 
 	// set max camera res, and use aspect ratio for window size...
 

--- a/src/lib/extractor/Scanner.cpp
+++ b/src/lib/extractor/Scanner.cpp
@@ -21,7 +21,7 @@ namespace {
 	{
 		if (i < 0)
 			i = N-1;
-		else if (i > N-1)
+		else if (i >= N)
 			i = 0;
 		return i;
 	}
@@ -115,7 +115,7 @@ bool Scanner::sort_top_to_bottom(std::vector<Anchor>& anchors)
 
 	// because of how we ordered our edges, the index of the longest edge is also the index of the anchor opposite it.
 	int top_left = get_longest_edge(edges);
-	int top_right;
+	int top_right, bottom_left;
 
 	// now, we need to find the order of the other two:
 	const point<int>& departing_edge = edges[fix_index<3>(top_left - 1)];
@@ -124,15 +124,18 @@ bool Scanner::sort_top_to_bottom(std::vector<Anchor>& anchors)
 	point<int> overlap = departing_edge - incoming_edge;
 
 	if (overlap.dot(overlap) < departing_edge.dot(departing_edge))
+	{
 		top_right = fix_index<3>(top_left + 1);
+		bottom_left = fix_index<3>(top_left - 1);
+	}
 	else
+	{
 		top_right = fix_index<3>(top_left - 1);
+		bottom_left = fix_index<3>(top_left + 1);
+	}
 
 	// apply the order.
-	if (&anchors[0] != &anchors[top_left])
-		std::swap(anchors[0], anchors[top_left]);
-	if (top_left != 1 and top_right != 1)
-		std::swap(anchors[1], anchors[2]);
+	anchors = {anchors[top_left], anchors[top_right], anchors[bottom_left]};
 	return true;
 }
 

--- a/src/lib/extractor/Scanner.cpp
+++ b/src/lib/extractor/Scanner.cpp
@@ -123,7 +123,7 @@ bool Scanner::sort_top_to_bottom(std::vector<Anchor>& anchors)
 	incoming_edge = {-incoming_edge.y(), incoming_edge.x()}; // rotate
 	point<int> overlap = departing_edge - incoming_edge;
 
-	if (overlap.dot(overlap) < edges[departing_edge].dot(edges[departing_edge]))
+	if (overlap.dot(overlap) < departing_edge.dot(departing_edge))
 		top_right = fix_index<3>(top_left + 1);
 	else
 		top_right = fix_index<3>(top_left - 1);

--- a/src/lib/extractor/Scanner.h
+++ b/src/lib/extractor/Scanner.h
@@ -41,7 +41,7 @@ public: // public inline methods
 public: // other interesting methods
 	std::vector<Anchor> deduplicate_candidates(const std::vector<Anchor>& candidates) const;
 	unsigned filter_candidates(std::vector<Anchor>& candidates) const;
-	bool sort_top_to_bottom(std::vector<Anchor>& anchors);
+	static bool sort_top_to_bottom(std::vector<Anchor>& anchors);
 
 	template <typename SCANTYPE>
 	void t1_scan_rows(std::function<void(const Anchor&)> fun, int skip=-1, int y=-1, int yend=-1, int xstart=-1, int xend=-1) const;

--- a/src/lib/extractor/test/ScannerTest.cpp
+++ b/src/lib/extractor/test/ScannerTest.cpp
@@ -210,34 +210,42 @@ TEST_CASE( "ScannerTest/testScanEdges", "[unit]" )
 
 TEST_CASE( "ScannerTest/testSortTopToBottom", "[unit]" )
 {
-	cv::Mat img = TestCimbar::loadSample("6bit/4_30_f0_627.jpg");
-	Scanner sc(img);
-
 	std::vector<Anchor> candidates;
 	candidates.push_back(Anchor(300, 360, 100, 160));
 	candidates.push_back(Anchor(300, 360, 300, 360));
 	candidates.push_back(Anchor(100, 160, 300, 360));
-	assertTrue( sc.sort_top_to_bottom(candidates) ); // make this a static function?
+	assertTrue( Scanner::sort_top_to_bottom(candidates) );
 
 	assertEquals(
-	    "330+-30,330+-30 330+-30,130+-30 130+-30,330+-30",
-	    turbo::str::join(candidates)
+		"330+-30,330+-30 130+-30,330+-30 330+-30,130+-30",
+		turbo::str::join(candidates)
 	);
 }
 
 TEST_CASE( "ScannerTest/testSortTopToBottom.2", "[unit]" )
 {
-	cv::Mat img = TestCimbar::loadSample("6bit/4_30_f0_627.jpg");
-	Scanner sc(img);
-
 	std::vector<Anchor> candidates;
 	candidates.push_back(Anchor(966, 1020, 966, 1020));
 	candidates.push_back(Anchor(966, 1020, 2, 56));
 	candidates.push_back(Anchor(2, 56, 966, 1020));
-	assertTrue( sc.sort_top_to_bottom(candidates) );
+	assertTrue( Scanner::sort_top_to_bottom(candidates) );
 
 	assertEquals(
 	    "993+-27,993+-27 29+-27,993+-27 993+-27,29+-27",
 	    turbo::str::join(candidates)
+	);
+}
+
+TEST_CASE( "ScannerTest/testSortTopToBottom.3", "[unit]" )
+{
+	std::vector<Anchor> candidates;
+	candidates.push_back(Anchor(383, 437, 994, 1048));
+	candidates.push_back(Anchor(395, 447, 107, 157));
+	candidates.push_back(Anchor(1250, 1296, 124, 170));
+	assertTrue( Scanner::sort_top_to_bottom(candidates) );
+
+	assertEquals(
+		"421+-26,132+-25 1273+-23,147+-23 410+-27,1021+-27",
+		turbo::str::join(candidates)
 	);
 }

--- a/src/lib/gui/gl_program.h
+++ b/src/lib/gui/gl_program.h
@@ -3,6 +3,7 @@
 
 #include <GLES3/gl3.h>
 #include <GLES2/gl2ext.h>
+#include <iostream>
 #include <string>
 
 namespace cimbar {

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -56,6 +56,14 @@ public:
 		return glfwWindowShouldClose(_w);
 	}
 
+	void auto_scale_to_window()
+	{
+		if (!is_good())
+			return;
+		auto fun = [](GLFWwindow*, int w, int h){ glViewport(0, 0, w, h); };
+		glfwSetWindowSizeCallback(_w, fun);
+	}
+
 	void rotate(unsigned i=1)
 	{
 		if (_display)

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@ html, body {
 
 body {
 	background-color: white;
-	background-image: radial-gradient(circle at top left, rgb(7,0,0),rgb(244,244,244),rgb(255,255,255));
+	background-image: radial-gradient(circle at top left, rgb(7,0,0),transparent,transparent), repeating-linear-gradient(0deg, rgb(153,197,206) 0px, rgb(153,197,206) 1px, transparent 1px, transparent 30px), repeating-linear-gradient(0deg, rgb(153,197,206) 0px, rgb(153,197,206) 2px, transparent 2px, transparent 150px), repeating-linear-gradient(90deg, rgb(153,197,206) 0px, rgb(153,197,206) 1px, transparent 1px, transparent 30px),repeating-linear-gradient(90deg, rgb(153,197,206) 0px, rgb(153,197,206) 2px, transparent 2px, transparent 150px), linear-gradient(white, white);
 	background-size: cover;
 	color: gray;
 	display: grid;


### PR DESCRIPTION
* the finder pattern extract logic was, simply, broken (and frustratingly, the *test* was wrong). This would lead to decodes succeeding normally from some camera angles, and being ineffective from others.
* added `cimbar_recv` for linux (maybe other desktop OSs eventually). It is very barebones.
    * example command line: `./cimbar_recv -i /dev/video2 -o /tmp`
    * notably, there's no progress indicator yet. Configuration options are minimal.
    * it's basically a toy right now. Eventually it may be more useful.
* to help with autofocus (a bit), added a grid background to cimbar.js/.org