### PR TITLE
cli update: read input filenames from stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: make test CTEST_OUTPUT_ON_FAILURE=TRUE
 
+    - name: Usage test
+      working-directory: ${{runner.workspace}}/libcimbar/test/py
+      run: python3 -m unittest
+
   cppcheck:
     runs-on: ubuntu-18.04
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,17 @@ Encode:
 * large input files may fill up your disk with pngs!
 
 ```
-./cimbar --encode -i inputfile.txt -o outputprefix -f
+./cimbar --encode -i inputfile.txt -o outputprefix
 ```
 
 Decode (extracts file into output directory):
 ```
-./cimbar outputprefix*.png -o /tmp -f
+./cimbar outputprefix*.png -o /tmp
+```
+
+Decode a series of encoded images from stdin:
+```
+echo outputprefix*.png | ./cimbar -o /tmp
 ```
 
 Encode and animate to window:

--- a/src/exe/cimbar/CMakeLists.txt
+++ b/src/exe/cimbar/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(cimbar
 	wirehair
 	zstd
 	${OPENCV_LIBS}
+	${CPPFILESYSTEM}
 )
 
 add_custom_command(

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -12,7 +12,7 @@
 
 #include "cxxopts/cxxopts.hpp"
 
-#include <filesystem>
+#include <experimental/filesystem>
 #include <functional>
 #include <iostream>
 #include <string>
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
 		exit(0);
 	}
 
-	string outpath = std::filesystem::current_path();
+	string outpath = std::experimental::filesystem::current_path();
 	if (result.count("out"))
 		outpath = result["out"].as<string>();
 	std::cerr << "Output files will appear in " << outpath << std::endl;

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -5,6 +5,7 @@
 #include "FountainMetadata.h"
 #include "serialize/format.h"
 
+#include <cstdio>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -15,9 +16,10 @@ template <typename OUTSTREAM>
 class fountain_decoder_sink
 {
 public:
-	fountain_decoder_sink(std::string data_dir, unsigned chunk_size)
-	    : _dataDir(data_dir)
-	    , _chunkSize(chunk_size)
+	fountain_decoder_sink(std::string data_dir, unsigned chunk_size, bool log_writes=false)
+		: _dataDir(data_dir)
+		, _chunkSize(chunk_size)
+		, _logWrites(log_writes)
 	{
 	}
 
@@ -36,6 +38,8 @@ public:
 		std::string file_path = fmt::format("{}/{}", _dataDir, get_filename(md));
 		OUTSTREAM f(file_path);
 		f.write((char*)data.data(), data.size());
+		if (_logWrites)
+			printf("%s\n", file_path.c_str());
 		return true;
 	}
 
@@ -143,4 +147,5 @@ protected:
 	std::unordered_map<uint8_t, fountain_decoder_stream> _streams;
 	// track the uint32_t combo of (encode_id,size) to avoid redundant work
 	std::set<uint32_t> _done;
+	bool _logWrites;
 };

--- a/test/py/helpers.py
+++ b/test/py/helpers.py
@@ -1,0 +1,16 @@
+from os.path import join, realpath, dirname
+from tempfile import TemporaryDirectory
+
+CIMBAR_SRC = realpath(join(dirname(realpath(__file__)), '..', '..'))
+BIN_DIR = join(CIMBAR_SRC, 'dist', 'bin')
+
+
+class TestDirMixin():
+    def setUp(self):
+        self.working_dir = TemporaryDirectory()
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+        with self.working_dir:
+            pass

--- a/test/py/test_cimbar_cli.py
+++ b/test/py/test_cimbar_cli.py
@@ -1,0 +1,88 @@
+import subprocess
+from os.path import join as path_join, getsize
+from unittest import TestCase
+from unittest.mock import patch
+
+from helpers import TestDirMixin, CIMBAR_SRC, BIN_DIR
+
+
+CIMBAR_EXE = path_join(BIN_DIR, 'cimbar')
+
+
+def _get_command(*args):
+    cmd = [CIMBAR_EXE]
+    for arg in args:
+        if isinstance(arg, str):
+            cmd += arg.split(' ')
+        else:
+            cmd += arg
+    return cmd
+
+# look in dist/bin/ for executables
+# run them, confirm a few boring command results against samples(?)
+# at the very least, confirm a roundtrip and cli options....
+
+
+class CimbarCliTest(TestDirMixin, TestCase):
+    def test_roundtrip_oneshot(self):
+        # encode
+        infile = path_join(CIMBAR_SRC, 'LICENSE')
+        outprefix = path_join(self.working_dir.name, 'img')
+        cmd = _get_command('--encode -i', infile, '-o', outprefix)
+
+        res = subprocess.run(cmd, capture_output=True)
+        self.assertEqual(0, res.returncode)
+
+        encoded_img = f'{outprefix}_0.png'
+        self.assertTrue(getsize(encoded_img) > 30000)
+
+        # decode
+        cmd = _get_command('-i', encoded_img, '-o', self.working_dir.name)
+        res = subprocess.run(cmd, capture_output=True)
+        self.assertEqual(0, res.returncode)
+
+        # filename in stdout
+        decoded_file = res.stdout.strip().decode('utf-8')
+        self.assertTrue(self.working_dir.name in decoded_file)
+
+        with open(infile) as r:
+            expected = r.read()
+        with open(decoded_file) as r:
+            actual = r.read()
+
+        self.assertEqual(expected, actual)
+
+    def test_roundtrip_stdin(self):
+        # encode
+        infile = path_join(CIMBAR_SRC, 'LICENSE')
+        outprefix = path_join(self.working_dir.name, 'img')
+        cmd = _get_command('--encode -o', outprefix)
+
+        res = subprocess.run(
+            cmd, input=infile.encode('utf-8'), capture_output=True
+        )
+
+        self.assertEqual(0, res.returncode)
+
+        encoded_img = f'{outprefix}_0.png'
+        self.assertTrue(getsize(encoded_img) > 30000)
+
+        # decode defaults to cwd -- which should be self.working_dir
+        cmd = _get_command()
+        res = subprocess.run(
+            cmd, input=encoded_img.encode('utf-8'), capture_output=True,
+            cwd=self.working_dir.name,
+        )
+        self.assertEqual(0, res.returncode)
+
+        # filename in stdout
+        decoded_file = res.stdout.strip().decode('utf-8')
+        self.assertTrue(self.working_dir.name in decoded_file)
+
+        with open(infile) as r:
+            expected = r.read()
+        with open(decoded_file) as r:
+            actual = r.read()
+
+        self.assertEqual(expected, actual)
+

--- a/test/py/test_cimbar_cli.py
+++ b/test/py/test_cimbar_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+from subprocess import PIPE
 from os.path import join as path_join, getsize
 from unittest import TestCase
 from unittest.mock import patch
@@ -30,7 +31,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
         outprefix = path_join(self.working_dir.name, 'img')
         cmd = _get_command('--encode -i', infile, '-o', outprefix)
 
-        res = subprocess.run(cmd, capture_output=True)
+        res = subprocess.run(cmd, stdout=PIPE)
         self.assertEqual(0, res.returncode)
 
         encoded_img = f'{outprefix}_0.png'
@@ -38,7 +39,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
 
         # decode
         cmd = _get_command('-i', encoded_img, '-o', self.working_dir.name)
-        res = subprocess.run(cmd, capture_output=True)
+        res = subprocess.run(cmd, stdout=PIPE)
         self.assertEqual(0, res.returncode)
 
         # filename in stdout
@@ -59,7 +60,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
         cmd = _get_command('--encode -o', outprefix)
 
         res = subprocess.run(
-            cmd, input=infile.encode('utf-8'), capture_output=True
+            cmd, input=infile.encode('utf-8'), stdout=PIPE
         )
 
         self.assertEqual(0, res.returncode)
@@ -70,7 +71,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
         # decode defaults to cwd -- which should be self.working_dir
         cmd = _get_command()
         res = subprocess.run(
-            cmd, input=encoded_img.encode('utf-8'), capture_output=True,
+            cmd, input=encoded_img.encode('utf-8'), stdout=PIPE,
             cwd=self.working_dir.name,
         )
         self.assertEqual(0, res.returncode)


### PR DESCRIPTION
This should enable piping inputs from other processes, for example when decoding. It's not perfect -- there's not a good way to tell when `cimbar` is finished with an input (though it shouldn't take long) -- but it's a start.

Also:
* fountain mode (`-f`) is now the default. This includes zstd compression as well, and matches what cimbar.org and CFC do.
* when decoding, the `cimbar` binary will now log completed file paths to stdout after they're written
* I added a simple python(3) test for the `cimbar` binary. These API tests may be extended to testing an so/dll once a stable interface exists.