### PR TITLE
Pin "portable" linux script to use an old (known good) cmake

### DIFF
--- a/package-portable-linux.sh
+++ b/package-portable-linux.sh
@@ -14,7 +14,7 @@ apt install -y pkgconf g++-7 python-pip
 apt install -y libgles2-mesa-dev libglfw3-dev
 
 # cmake (via pip)
-python -m pip install cmake
+python -m pip install cmake==3.21.4
 
 # use gcc7
 update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-7 100


### PR DESCRIPTION
Found this while refreshing my memory about #84

The other dependencies were/are de-facto pinned (since ubuntu 16.04 has passed end of support), but this one wasn't.