### PR TITLE
Memory corruption fix (bad flood decode bounds check) :upside_down_face: 

### DIFF
--- a/src/lib/cimb_translator/AdjacentCellFinder.cpp
+++ b/src/lib/cimb_translator/AdjacentCellFinder.cpp
@@ -43,10 +43,10 @@ int AdjacentCellFinder::in_row_with_margin(int index) const
 
 int AdjacentCellFinder::right(int index) const
 {
-	int next = index+1;
-	if (next >= (int)_positions.size())
+	if (index < 0 || index >= (int)_positions.size() - 1)
 		return -1;
-	if (_positions[next].first < _positions[index].first)  // loop
+	int next = index + 1;
+	if (_positions[next].first < _positions[index].first)
 		return -1;
 	return next;
 }
@@ -63,16 +63,17 @@ int AdjacentCellFinder::left(int index) const
 
 int AdjacentCellFinder::bottom(int index) const
 {
+	if (index < 0 || index >= (int)_positions.size())
+		return -1;
 	int increment = _dimensions;
 	if (in_row_with_margin(index))
 		increment -= _markerSize;
 	int next = index + increment;
 	if (in_row_with_margin(next))
 		next -= _markerSize;
-
-	if (next >= (int)_positions.size())
+	if (next < 0 || next >= (int)_positions.size())
 		return -1;
-	if (_positions[next].first != _positions[index].first)  // near anchor
+	if (_positions[next].first != _positions[index].first)
 		return -1;
 	return next;
 }

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -103,10 +103,10 @@ int FloodDecodePositions::update(unsigned index, const CellDrift& drift, unsigne
 		{
 			std::array<int,4> horizon = {-1, -1, -1, -1};
 			horizon[0] = _cellFinder.right(rridx);
-			if (horizon[0])
+			if (horizon[0] >= 0)
 				horizon[1] = _cellFinder.right(horizon[0]);
 			horizon[2] = _cellFinder.left(llidx);
-			if (horizon[2])
+			if (horizon[2] >= 0)
 				horizon[3] = _cellFinder.left(horizon[2]);
 
 			update_adjacents(horizon, drift, error_distance, cooldown);
@@ -118,10 +118,10 @@ int FloodDecodePositions::update(unsigned index, const CellDrift& drift, unsigne
 		{
 			std::array<int,4> vert = {-1, -1, -1, -1};
 			vert[0] = _cellFinder.top(uuidx);
-			if (vert[0])
+			if (vert[0] >= 0)
 				vert[1] = _cellFinder.top(vert[0]);
 			vert[2] = _cellFinder.bottom(ddidx);
-			if (vert[2])
+			if (vert[2] >= 0)
 				vert[3] = _cellFinder.bottom(vert[2]);
 
 			update_adjacents(vert, drift, error_distance, cooldown);


### PR DESCRIPTION
Thanks to @notune for the discovery/stacktrace/fix! (the trifecta!)

Ported upstream from the cfc PR (sz3/cfc#29). I also fixed the logic one layer up (in FloodDecodePositions), so now we have some defense in depth...

sz3/cfc#29
sz3/cfc#28