### PR TITLE
Fix some longstanding (no)-fsanitize sloppiness

### DIFF
--- a/src/lib/bit_file/bitbuffer.h
+++ b/src/lib/bit_file/bitbuffer.h
@@ -61,15 +61,15 @@ public:
 
 	bool write(unsigned data, unsigned index, int length)
 	{
-		resize(index+length-1);
+		resize(index+length);
 
 		int currentByte = index/8;
 		int currentBit = index%8;
 
 		int nextWrite = std::min(length, 8-currentBit); // write this many bits
-		while (length > 0)
+		while (length > 0 and nextWrite > 0)
 		{
-			char bits = data >> (length - nextWrite);
+			unsigned char bits = data >> (length - nextWrite);
 			bits = bits << (8 - nextWrite - currentBit);
 			_buffer[currentByte] |= bits;
 
@@ -92,7 +92,7 @@ public:
 		int nextRead = std::min(length, 8-currentBit); // read this many bits
 		while (length > 0)
 		{
-			unsigned char bits = _buffer[currentByte] << currentBit;
+			unsigned char bits = static_cast<unsigned char>(_buffer[currentByte]) << currentBit;
 			bits = bits >> (8-nextRead);
 			res |= bits << (length - nextRead);
 

--- a/src/lib/cimb_translator/Common.cpp
+++ b/src/lib/cimb_translator/Common.cpp
@@ -57,7 +57,7 @@ cv::Mat load_img(string path)
 	vector<unsigned char> data(bytes.data(), bytes.data() + bytes.size());
 
 	int width, height, channels;
-	std::unique_ptr<uint8_t[]> imgdata(stbi_load_from_memory(data.data(), static_cast<int>(data.size()), &width, &height, &channels, STBI_rgb_alpha));
+	std::unique_ptr<uint8_t[], void (*)(void*)> imgdata(stbi_load_from_memory(data.data(), static_cast<int>(data.size()), &width, &height, &channels, STBI_rgb_alpha), ::free);
 	if (!imgdata)
 		return cv::Mat();
 

--- a/src/lib/cimb_translator/test/CimbDecoderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbDecoderTest.cpp
@@ -125,7 +125,7 @@ TEST_CASE( "CimbDecoderTest/testAllColorDecodes", "[unit]" )
 			DYNAMIC_SECTION( "testColor " << c << ":" << i )
 			{
 				cv::Mat tile = cimbar::getTile(4, i, true, 4, c);
-				cv::Mat tenxten(10, 10, tile.type());
+				cv::Mat tenxten(10, 10, tile.type(), {0,0,0});
 				tile.copyTo(tenxten(cv::Rect(cv::Point(1, 1), tile.size())));
 
 				unsigned color = cd.decode_color(Cell(tenxten));


### PR DESCRIPTION
* Off by one in bitbuffer that we were only hitting in tests (hopefully)
* a malloc+delete no-no (changed the `unique_ptr` deallocator to `free`)
* explicit init of a cv::Mat() in CimbDecoderTest

I'd like to enable `-fsanitize=undefined,address` by default (at least for dev builds), but we'll need to fix some library dependencies first.