### PR TITLE
Functionality to split encoding/decoding of colors and symbols

### DIFF
--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
 	}
 
 	// else, the good stuff
-	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc);
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits());
 	if (compressionLevel <= 0)
 	{
 		fountain_decoder_sink<std::ofstream> sink(outpath, chunkSize, true);

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -269,7 +269,7 @@ int main(int argc, char** argv)
 	// else, the good stuff
 	int res = -200;
 
-	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits());
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits(), legacy_mode);
 	if (compressionLevel <= 0)
 	{
 		fountain_decoder_sink<std::ofstream> sink(outpath, chunkSize, true);

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
 	unsigned color_mode = legacy_mode? 0 : 1;
 	Decoder dec(-1, -1, color_mode, legacy_mode);
 
-	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits());
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits(), legacy_mode);
 	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> sink(outpath, chunkSize);
 
 	cv::Mat mat;

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -41,10 +41,10 @@ int main(int argc, char** argv)
 	options.add_options()
 		("i,in", "Video source.", cxxopts::value<string>())
 		("o,out", "Output directory (decoding).", cxxopts::value<string>())
-	    ("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
+		("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
 		("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
 		("f,fps", "Target decode FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
-	    ("h,help", "Print usage")
+		("h,help", "Print usage")
 	;
 	options.show_positional_help();
 	options.parse_positional({"in", "out"});
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
 	Extractor ext;
 	Decoder dec;
 
-	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc);
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits());
 	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> sink(outpath, chunkSize);
 
 	cv::Mat mat;

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -91,7 +91,9 @@ int main(int argc, char** argv)
 					continue;
 				}
 
-				if (!encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), static_cast<int>(i)))
+				// start encode_id is 109. This is mostly unimportant (it only needs to wrap between [0,127]), but useful
+				// for the decoder -- because it gives it a better distribution of colors in the first frame header it sees.
+				if (!encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), static_cast<int>(i+109)))
 				{
 					std::cerr << "failed to encode file " << infiles[i] << std::endl;
 					continue;

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -42,6 +42,7 @@ int main(int argc, char** argv)
 		("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
 		("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
 		("f,fps", "Target FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
+		("m,mode", "Select a cimbar mode. B (the default) is new to 0.6.x. 4C is the 0.5.x config. [B,4C]", cxxopts::value<string>()->default_value("B"))
 		("z,compression", "Compression level. 0 == no compression.", cxxopts::value<int>()->default_value(turbo::str::str(compressionLevel)))
 		("h,help", "Print usage")
 	;
@@ -61,6 +62,14 @@ int main(int argc, char** argv)
 	colorBits = std::min(3, result["colorbits"].as<int>());
 	compressionLevel = result["compression"].as<int>();
 	ecc = result["ecc"].as<unsigned>();
+
+	bool legacy_mode = false;
+	if (result.count("mode"))
+	{
+		string mode = result["mode"].as<string>();
+		legacy_mode = (mode == "4c") or (mode == "4C");
+	}
+
 	unsigned fps = result["fps"].as<unsigned>();
 	if (fps == 0)
 		fps = defaultFps;
@@ -73,7 +82,7 @@ int main(int argc, char** argv)
 		return 70;
 	}
 
-	configure(colorBits, ecc, compressionLevel);
+	configure(colorBits, ecc, compressionLevel, legacy_mode);
 
 	std::chrono::time_point start = std::chrono::high_resolution_clock::now();
 	while (true)

--- a/src/lib/bit_file/bitbuffer.h
+++ b/src/lib/bit_file/bitbuffer.h
@@ -125,6 +125,12 @@ public:
 		return _buffer;
 	}
 
+	void copy_to_buffer(const char* data, unsigned size)
+	{
+		_buffer.resize(size, 0);
+		std::copy(data, data+size, _buffer.data());
+	}
+
 	writer get_writer(size_t pos=0)
 	{
 		return writer(*this, pos);

--- a/src/lib/bit_file/test/bitbufferTest.cpp
+++ b/src/lib/bit_file/test/bitbufferTest.cpp
@@ -144,3 +144,17 @@ TEST_CASE( "bitbufferTest/testOverwrite", "[unit]" )
 	assertEquals( '.', bb.buffer()[0x3f5] );
 	assertEquals( 't', bb.buffer()[0x3f6] );
 }
+
+TEST_CASE( "bitbufferTest/testCopyToBuffer", "[unit]" )
+{
+	bitbuffer bb;
+
+	std::string hello = "hello";
+	bb.copy_to_buffer(hello.data(), 5);
+
+	assertEquals( 0x68, bb.read(0, 8) );
+	assertEquals( 0x65, bb.read(8, 8) );
+	assertEquals( 0x6c, bb.read(16, 8) );
+	assertEquals( 0x6c, bb.read(24, 8) );
+	assertEquals( 0x6f, bb.read(32, 8) );
+}

--- a/src/lib/chromatic_adaptation/color_correction.h
+++ b/src/lib/chromatic_adaptation/color_correction.h
@@ -3,6 +3,8 @@
 
 #include <opencv2/opencv.hpp>
 
+#include <iostream>
+
 // transforms are in adaptation_transform.h
 // http://brucelindbloom.com/Eqn_ChromAdapt.html
 
@@ -23,15 +25,30 @@ public:
 		return transform().inv() * d * transform();
 	}
 
+	static inline cv::Matx<float, 3, 3> get_moore_penrose_lsm(const cv::Mat& actual, const cv::Mat& desired)
+	{
+		// 1. TODO: make sure actual and desired dims match?
+		// 2. the calculation is MoorePenrose least squares mapping:
+		//  in numpy, it's dot(transpose(x), pinv(transpose(y)))
+
+		cv::Mat x, y, z;
+		cv::transpose(desired, x);
+		cv::transpose(actual, y);
+		cv::invert(y, z, cv::DECOMP_SVD);
+
+		y = x * z;
+		return y;
+	}
+
 public:
 	color_correction()
-	    : _active(false)
+		: _active(false)
 	{
 	}
 
 	color_correction(cv::Matx<float, 3, 3>&& m)
-	    : _m(m)
-	    , _active(true)
+		: _m(m)
+		, _active(true)
 	{
 	}
 

--- a/src/lib/chromatic_adaptation/color_correction.h
+++ b/src/lib/chromatic_adaptation/color_correction.h
@@ -3,8 +3,6 @@
 
 #include <opencv2/opencv.hpp>
 
-#include <iostream>
-
 // transforms are in adaptation_transform.h
 // http://brucelindbloom.com/Eqn_ChromAdapt.html
 
@@ -27,10 +25,10 @@ public:
 
 	static inline cv::Matx<float, 3, 3> get_moore_penrose_lsm(const cv::Mat& actual, const cv::Mat& desired)
 	{
-		// 1. TODO: make sure actual and desired dims match?
-		// 2. the calculation is MoorePenrose least squares mapping:
-		//  in numpy, it's dot(transpose(x), pinv(transpose(y)))
-
+		// inspired by the python colour-science package. It's not complicated,
+		// but I didn't know that going in.
+		// See also:
+		// https://en.wikipedia.org/wiki/Moore-Penrose_inverse
 		cv::Mat x, y, z;
 		cv::transpose(desired, x);
 		cv::transpose(actual, y);

--- a/src/lib/chromatic_adaptation/test/color_correctionTest.cpp
+++ b/src/lib/chromatic_adaptation/test/color_correctionTest.cpp
@@ -19,8 +19,8 @@ TEST_CASE( "color_correctionTest/testTransform", "[unit]" )
 		std::stringstream ss;
 		ss << mat;
 		assertEquals( "[1.0655777, 0.2109226, -0.013239831;\n"
-		              " 0.023168325, 0.98723376, -0.0046780901;\n"
-		              " 0, 0, 1]", ss.str() );
+					  " 0.023168325, 0.98723376, -0.0046780901;\n"
+					  " 0, 0, 1]", ss.str() );
 	}
 
 	std::tuple<float, float, float> c = color_correction(std::move(mat)).transform(180, 98, 255);
@@ -29,3 +29,60 @@ TEST_CASE( "color_correctionTest/testTransform", "[unit]" )
 	assertAlmostEquals( 255, std::get<2>(c) );
 }
 
+TEST_CASE( "color_correctionTest/testComputeMoorePenrose", "[unit]" )
+{
+	cv::Mat actual = (cv::Mat_<float>(5,3) <<
+				   0, 142.31060606, 0,
+				   0, 148.75, 148.75,
+				   148.75, 148.75, 0,
+				   148.75, 0, 148.75,
+				   255, 255, 255);
+
+	cv::Mat desired = (cv::Mat_<float>(5,3) <<
+				   0, 255, 0,
+				   0, 255, 255,
+				   255, 255, 0,
+				   255, 0, 255,
+				   255, 255, 255);
+
+	std::cout << actual << std::endl;
+	std::cout << desired << std::endl;
+
+	cv::Matx<float, 3, 3> mat = color_correction::get_moore_penrose_lsm(actual, desired);
+	{
+		std::stringstream ss;
+		ss << mat;
+		assertEquals( "[1.5223049, -0.10023587, -0.19198087;\n"
+					  " -0.20533442, 1.6441474, -0.20533434;\n"
+					  " -0.19198078, -0.10023584, 1.5223049]", ss.str() );
+	}
+}
+
+TEST_CASE( "color_correctionTest/testComputeMoorePenrose.2", "[unit]" )
+{
+	cv::Mat actual = (cv::Mat_<float>(5,3) <<
+					  14.58901515, 115.74431818, 39.88320707,
+					  19.34027778, 124.4375, 115.37152778,
+					  140.70486111, 137.45833333, 65.50694444,
+					  131.59722222, 41.22222222, 104.84027778,
+					  171.625, 163.625, 158.875);
+
+	cv::Mat desired = (cv::Mat_<float>(5,3) <<
+				   0, 255, 0,
+				   0, 255, 255,
+				   255, 255, 0,
+				   255, 0, 255,
+				   255, 255, 255);
+
+	std::cout << actual << std::endl;
+	std::cout << desired << std::endl;
+
+	cv::Matx<float, 3, 3> mat = color_correction::get_moore_penrose_lsm(actual, desired);
+	{
+		std::stringstream ss;
+		ss << mat;
+		assertEquals( "[2.0261116, -0.21691091, -0.19806443;\n"
+					  " -0.43822661, 2.4562523, -0.41700464;\n"
+					  " -0.55769891, -1.1443435, 3.4819376]", ss.str() );
+	}
+}

--- a/src/lib/chromatic_adaptation/test/color_correctionTest.cpp
+++ b/src/lib/chromatic_adaptation/test/color_correctionTest.cpp
@@ -45,9 +45,6 @@ TEST_CASE( "color_correctionTest/testComputeMoorePenrose", "[unit]" )
 				   255, 0, 255,
 				   255, 255, 255);
 
-	std::cout << actual << std::endl;
-	std::cout << desired << std::endl;
-
 	cv::Matx<float, 3, 3> mat = color_correction::get_moore_penrose_lsm(actual, desired);
 	{
 		std::stringstream ss;
@@ -73,9 +70,6 @@ TEST_CASE( "color_correctionTest/testComputeMoorePenrose.2", "[unit]" )
 				   255, 255, 0,
 				   255, 0, 255,
 				   255, 255, 255);
-
-	std::cout << actual << std::endl;
-	std::cout << desired << std::endl;
 
 	cv::Matx<float, 3, 3> mat = color_correction::get_moore_penrose_lsm(actual, desired);
 	{

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -145,6 +145,11 @@ unsigned CimbDecoder::check_color_distance(std::tuple<uchar,uchar,uchar> a, std:
 	return color_diff(a, b);
 }
 
+std::tuple<uchar,uchar,uchar> CimbDecoder::get_color(int i) const
+{
+	return cimbar::getColor(i, _numColors, 1);  // 1=color_mode...
+}
+
 unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 {
 	// transform color with ccm
@@ -168,7 +173,7 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 	float best_distance = 1000000;
 	for (unsigned i = 0; i < _numColors; ++i)
 	{
-		std::tuple<uchar,uchar,uchar> candidate = cimbar::getColor(i, _numColors, 1); // color_mode...
+		std::tuple<uchar,uchar,uchar> candidate = get_color(i);
 		unsigned distance = check_color_distance(c, candidate);
 		if (distance < best_distance)
 		{

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -13,9 +13,12 @@
 using std::get;
 using std::string;
 
+const int FIX_THRESH_HIGH = 245;
+const int FIX_THRESH_LOW = 0;
+const float BEST_COLOR_FLOOR = 100.0f;
+
 namespace {
-	template <typename T>
-	unsigned squared_difference(T a, T b)
+	unsigned squared_difference(int a, int b)
 	{
 		return std::pow(a - b, 2);
 	}
@@ -24,9 +27,9 @@ namespace {
 	{
 		c -= down;
 		c *= adjustUp;
-		if (c > (245 - down))
+		if (c > FIX_THRESH_HIGH)
 			c = 255;
-		if (c < 0)
+		if (c < FIX_THRESH_LOW)
 			c = 0;
 		return (uchar)c;
 	}
@@ -154,7 +157,7 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 	}
 
 	float max = std::max({r, g, b, 1.0f});
-	float min = std::min({r, g, b, 48.0f});
+	float min = std::min({r, g, b, BEST_COLOR_FLOOR});
 	float adjust = 255.0;
 	if (min >= max)
 		min = 0;

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -169,7 +169,7 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 	float best_distance = 1000000;
 	for (unsigned i = 0; i < _numColors; ++i)
 	{
-		std::tuple<uchar,uchar,uchar> candidate = cimbar::getColor(i, _numColors);
+		std::tuple<uchar,uchar,uchar> candidate = cimbar::getColor(i, _numColors, 1); // color_mode...
 		unsigned distance = check_color_distance(c, candidate);
 		if (distance < best_distance)
 		{

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -15,7 +15,7 @@ using std::string;
 
 const int FIX_THRESH_HIGH = 245;
 const int FIX_THRESH_LOW = 0;
-const float BEST_COLOR_FLOOR = 100.0f;
+const float BEST_COLOR_FLOOR = 48.0f;
 
 namespace {
 	unsigned squared_difference(int a, int b)
@@ -27,7 +27,7 @@ namespace {
 	{
 		c -= down;
 		c *= adjustUp;
-		if (c > FIX_THRESH_HIGH)
+		if (c > (FIX_THRESH_HIGH-down))
 			c = 255;
 		if (c < FIX_THRESH_LOW)
 			c = 0;

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -54,10 +54,11 @@ namespace {
 	}
 }
 
-CimbDecoder::CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark, uchar ahashThreshold)
+CimbDecoder::CimbDecoder(unsigned symbol_bits, unsigned color_bits, unsigned color_mode, bool dark, uchar ahashThreshold)
 	: _symbolBits(symbol_bits)
 	, _numSymbols(1 << symbol_bits)
 	, _numColors(1 << color_bits)
+	, _colorMode(color_mode)
 	, _dark(dark)
 	, _ahashThreshold(ahashThreshold)
 {
@@ -156,7 +157,7 @@ unsigned CimbDecoder::check_color_distance(std::tuple<uchar,uchar,uchar> a, std:
 
 std::tuple<uchar,uchar,uchar> CimbDecoder::get_color(int i) const
 {
-	return cimbar::getColor(i, _numColors, 1);  // 1=color_mode...
+	return cimbar::getColor(i, _numColors, _colorMode);
 }
 
 unsigned CimbDecoder::get_best_color(float r, float g, float b) const

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -199,7 +199,7 @@ std::tuple<uchar,uchar,uchar> CimbDecoder::avg_color(const Cell& color_cell) con
 	// limit dimensions to ignore outer row/col. We want to look at the middle 6x6, or 3x3...
 	Cell center = color_cell;
 	center.crop(1, 1, color_cell.cols()-2, color_cell.rows()-2);
-	return center.mean_rgb(center.cols() > 4? Cell::SKIP : 0);
+	return center.mean_rgb();
 }
 
 unsigned CimbDecoder::decode_color(const Cell& color_cell) const

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -158,10 +158,9 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 
 	float max = std::max({r, g, b, 1.0f});
 	float min = std::min({r, g, b, BEST_COLOR_FLOOR});
-	float adjust = 255.0;
 	if (min >= max)
 		min = 0;
-	adjust /= (max - min);
+	float adjust = 255.0/(max - min);
 
 	std::tuple<uchar,uchar,uchar> c = fix_color({r, g, b}, adjust, min);
 

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -64,8 +64,17 @@ CimbDecoder::CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark, u
 	load_tiles();
 }
 
+const color_correction& CimbDecoder::get_ccm() const
+{
+	// testing purposes only.
+	// this returning a thread local would be fine, iff we only use it for debugging!
+	return _ccm;
+}
+
 void CimbDecoder::update_color_correction(cv::Matx<float, 3, 3>&& ccm)
 {
+	// TODO: threadlocal?
+	// because this is dubious to begin with...
 	_ccm.update(std::move(ccm));
 }
 

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -179,16 +179,20 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 	return best_fit;
 }
 
-unsigned CimbDecoder::decode_color(const Cell& color_cell) const
+std::tuple<uchar,uchar,uchar> CimbDecoder::avg_color(const Cell& color_cell) const
 {
-	if (_numColors <= 1)
-		return 0;
-
 	// TODO: check/enforce dimensions of color_cell?
 	// limit dimensions to ignore outer row/col. We want to look at the middle 6x6, or 3x3...
 	Cell center = color_cell;
 	center.crop(1, 1, color_cell.cols()-2, color_cell.rows()-2);
-	auto [r, g, b] = center.mean_rgb(center.cols() > 4? Cell::SKIP : 0);
+	return center.mean_rgb(center.cols() > 4? Cell::SKIP : 0);
+}
+
+unsigned CimbDecoder::decode_color(const Cell& color_cell) const
+{
+	if (_numColors <= 1)
+		return 0;
+	auto [r, g, b] = avg_color(color_cell);
 	return get_best_color(r, g, b);
 }
 

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -21,6 +21,7 @@ public:
 	unsigned decode_symbol(const cv::Mat& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 
+	std::tuple<uchar,uchar,uchar> avg_color(const Cell& color_cell) const;
 	unsigned get_best_color(float r, float g, float b) const;
 	unsigned decode_color(const Cell& cell) const;
 

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -13,7 +13,7 @@
 class CimbDecoder
 {
 public:
-	CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark=true, uchar ahashThreshold=0);
+	CimbDecoder(unsigned symbol_bits, unsigned color_bits, unsigned color_mode=1, bool dark=true, uchar ahashThreshold=0);
 
 	const color_correction& get_ccm() const;
 	void update_color_correction(cv::Matx<float, 3, 3>&& ccm);
@@ -42,6 +42,7 @@ protected:
 	unsigned _symbolBits;
 	unsigned _numSymbols;
 	unsigned _numColors;
+	unsigned _colorMode;
 	bool _dark;
 	uchar _ahashThreshold;
 	color_correction _ccm;

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -21,6 +21,7 @@ public:
 	unsigned decode_symbol(const cv::Mat& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 
+	std::tuple<uchar,uchar,uchar> get_color(int i) const;
 	std::tuple<uchar,uchar,uchar> avg_color(const Cell& color_cell) const;
 	unsigned get_best_color(float r, float g, float b) const;
 	unsigned decode_color(const Cell& cell) const;

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -15,6 +15,7 @@ class CimbDecoder
 public:
 	CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark=true, uchar ahashThreshold=0);
 
+	const color_correction& get_ccm() const;
 	void update_color_correction(cv::Matx<float, 3, 3>&& ccm);
 
 	unsigned get_best_symbol(image_hash::ahash_result<cimbar::Config::cell_size()>& results, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;

--- a/src/lib/cimb_translator/CimbEncoder.cpp
+++ b/src/lib/cimb_translator/CimbEncoder.cpp
@@ -8,10 +8,11 @@
 using cv::Vec3b;
 using std::string;
 
-CimbEncoder::CimbEncoder(unsigned symbol_bits, unsigned color_bits, bool dark)
-    : _numSymbols(1 << symbol_bits)
-    , _numColors(1 << color_bits)
-    , _dark(dark)
+CimbEncoder::CimbEncoder(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode)
+	: _numSymbols(1 << symbol_bits)
+	, _numColors(1 << color_bits)
+	, _dark(dark)
+	, _colorMode(color_mode)
 {
 	load_tiles(symbol_bits);
 }
@@ -20,7 +21,7 @@ cv::Mat CimbEncoder::load_tile(unsigned symbol_bits, unsigned index)
 {
 	unsigned symbol = index % _numSymbols;
 	unsigned color = index / _numSymbols;
-	return cimbar::getTile(symbol_bits, symbol, _dark, _numColors, color);
+	return cimbar::getTile(symbol_bits, symbol, _dark, _numColors, color, _colorMode);
 }
 
 // dir will need to be passed via env? Doesn't make sense to compile it in, and doesn't *really* make sense to use cwd

--- a/src/lib/cimb_translator/CimbEncoder.h
+++ b/src/lib/cimb_translator/CimbEncoder.h
@@ -9,7 +9,7 @@
 class CimbEncoder
 {
 public:
-	CimbEncoder(unsigned symbol_bits=4, unsigned color_bits=2, bool dark=true);
+	CimbEncoder(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1);
 
 	cv::Mat load_tile(unsigned symbol_bits, unsigned index);
 	bool load_tiles(unsigned symbol_bits);
@@ -21,4 +21,5 @@ protected:
 	unsigned _numSymbols;
 	unsigned _numColors;
 	bool _dark;
+	unsigned _colorMode;
 };

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -144,6 +144,30 @@ bool CimbReader::done() const
 	return !_good or _positions.done();
 }
 
+void CimbReader::init_ccm()
+{
+	// if no fountain header, we use a simplified von kries matrix?
+	// or maybe don't bother? Might be easier if we treat it as authoritative (but old),
+	// rather than having a "good" CCM saved sometimes, but not always.
+	if (_fountainColorHeader.id() == 0) // & decoder CCM isn't set?
+	{
+		//updateColorCorrection(_image, decoder);
+		return;
+	}
+
+	// should most of this logic go into CimbDecoder?
+
+	// full ccm, using header values as known color index
+	// 1. get positions
+	// 2. put fountain header into a bitbuffer so we can read decoder.color_bits() bits at a time
+	// 3. using expected fountain headers, decode color for each position
+	// 4. sample corners
+	// 5. group results from #3 and #4 by expected color index, compute avgs
+	// 6. generate ccm from avgs in #5
+	// 7. save ccm in decoder. Success! We hope
+
+}
+
 void CimbReader::update_metadata(char* buff, unsigned len)
 {
 	if (len == 0 and _fountainColorHeader.id() == 0)

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -9,10 +9,7 @@
 #include "bit_file/bitmatrix.h"
 #include "chromatic_adaptation/adaptation_transform.h"
 #include "chromatic_adaptation/color_correction.h"
-#include "serialize/format.h"
-
 #include <opencv2/opencv.hpp>
-#include <iostream>
 
 using namespace cimbar;
 

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -85,7 +85,7 @@ namespace {
 		return bestColor;
 	}
 
-	bool updateColorCorrection(const cv::Mat& img, CimbDecoder& decoder)
+	bool simpleColorCorrection(const cv::Mat& img, CimbDecoder& decoder)
 	{
 		std::tuple<float, float, float> white = calculateWhite(img, Config::dark());
 		decoder.update_color_correction(color_correction::get_adaptation_matrix<adaptation_transform::von_kries>(white, {255.0, 255.0, 255.0}));
@@ -93,25 +93,26 @@ namespace {
 	}
 }
 
-CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen, bool color_correction)
+CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen, int color_correction)
 	: _image(img)
 	, _fountainColorHeader(0U)
 	, _cellSize(Config::cell_size() + 2)
 	, _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding())
 	, _decoder(decoder)
 	, _good(_image.cols >= Config::image_size() and _image.rows >= Config::image_size())
+	, _colorCorrection(color_correction)
 {
 	_grayscale = preprocessSymbolGrid(img, needs_sharpen);
-	if (_good and color_correction)
-		updateColorCorrection(_image, decoder);
+	if (_good and color_correction == 1)
+		simpleColorCorrection(_image, decoder);
 }
 
-CimbReader::CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen, bool color_correction)
+CimbReader::CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen, int color_correction)
 	: CimbReader(img.getMat(cv::ACCESS_READ), decoder, needs_sharpen, color_correction)
 {
 }
 
-unsigned CimbReader::read_color(const PositionData& pos)
+unsigned CimbReader::read_color(const PositionData& pos) const
 {
 	Cell color_cell(_image, pos.x, pos.y, Config::cell_size(), Config::cell_size());
 	return _decoder.decode_color(color_cell);
@@ -149,16 +150,17 @@ bool CimbReader::done() const
 
 void CimbReader::init_ccm(unsigned color_bits, unsigned interleave_blocks, unsigned interleave_partitions, unsigned fountain_blocks)
 {
-	// if no fountain header, we use a simplified von kries matrix?
-	// or maybe don't bother? Might be easier if we treat it as authoritative (but old),
-	// rather than having a "good" CCM saved sometimes, but not always.
-	if (_fountainColorHeader.id() == 0) // && decoder CCM isn't set?
-	{
-		//updateColorCorrection(_image, decoder);
+	if (_colorCorrection != 2)
 		return;
-	}
 
-	// should most of this logic go into CimbDecoder?
+	// if no fountain header, we don't attempt color correction
+	// we *could* (and used to) sample white pixels in the anchor points, and use the von kries/bradford matrix to generate a primitive CCM
+	// but for now we're aiming for something a bit smarter
+	if (_fountainColorHeader.id() == 0) // and _decoder.has_no_ccm() ... or something?
+		return;
+
+	// TODO: refactor?
+	// most logical thing to do is probably to make a get_color_map(), and leave the rest (avg computation, etc) here...?
 
 	// full ccm, using header values as known color index
 	// 1. get positions
@@ -166,7 +168,6 @@ void CimbReader::init_ccm(unsigned color_bits, unsigned interleave_blocks, unsig
 	CellPositions::positions_list positions = Interleave::interleave(_positions.positions(), interleave_blocks, interleave_partitions);
 
 	// 3. using expected fountain headers, decode color for each position
-
 	unsigned end = cimbar::Config::capacity(color_bits) * 8 / color_bits;
 	unsigned headerStartInterval = cimbar::Config::capacity(_decoder.symbol_bits() + color_bits) * 8 / fountain_blocks / color_bits;
 	unsigned headerLen = (_fountainColorHeader.md_size) * 8 / color_bits; // shrink this to md_size-2 to discard the block_id bytes...
@@ -188,8 +189,11 @@ void CimbReader::init_ccm(unsigned color_bits, unsigned interleave_blocks, unsig
 			unsigned expected = buff.read(i, color_bits);
 			CellPositions::coordinate pos = positions[idx];
 
-			Cell color_cell(_image, pos.first, pos.second, Config::cell_size(), Config::cell_size());
-			auto col = _decoder.avg_color(color_cell); // could just call cell mean_rgb directly?
+			//Cell color_cell(_image, pos.first, pos.second, Config::cell_size(), Config::cell_size());
+			//auto col = _decoder.avg_color(color_cell); // could just call cell mean_rgb directly?
+
+			Cell color_cell(_image, pos.first+1, pos.second+1, Config::cell_size()-2, Config::cell_size()-2);
+			auto col = color_cell.mean_rgb();
 
 			auto [it, isNew] = colors.try_emplace(expected, std::make_tuple(0, 0, 0, 0)); // count,r,g,b
 			std::get<0>(it->second) += 1;
@@ -237,12 +241,8 @@ void CimbReader::init_ccm(unsigned color_bits, unsigned interleave_blocks, unsig
 		desired.push_back(drow);
 	}
 
-	// 6. generate ccm from avgs in #4/5
-	cv::Matx<float, 3, 3> ccm = color_correction::get_moore_penrose_lsm(actual, desired);
-	std::cout << "resulting ccm is " << ccm << std::endl;
-
-	// 7. save ccm in decoder. Success! We hope
-
+	// 6. generate ccm from avgs in #4/5, save in decoder. Success! We hope
+	_decoder.update_color_correction(color_correction::get_moore_penrose_lsm(actual, desired));
 }
 
 void CimbReader::update_metadata(char* buff, unsigned len)
@@ -253,7 +253,6 @@ void CimbReader::update_metadata(char* buff, unsigned len)
 	if (_fountainColorHeader.id() == 0)
 		_fountainColorHeader = FountainMetadata(buff, len);
 
-	std::cout << fmt::format("FountainMd {}, {}, {}", _fountainColorHeader.encode_id(), _fountainColorHeader.file_size(), _fountainColorHeader.block_id()) << std::endl;
 	_fountainColorHeader.increment_block_id(); // we always want to be +1
 }
 

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -19,6 +19,7 @@ public:
 	unsigned read_color(const PositionData& pos);
 	bool done() const;
 
+	void init_ccm();
 	void update_metadata(char* buff, unsigned len);
 
 	unsigned num_reads() const;

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -19,7 +19,7 @@ public:
 	unsigned read_color(const PositionData& pos);
 	bool done() const;
 
-	void init_ccm();
+	void init_ccm(unsigned color_bits, unsigned interleave_blocks, unsigned interleave_partitions, unsigned fountain_blocks);
 	void update_metadata(char* buff, unsigned len);
 
 	unsigned num_reads() const;

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -12,11 +12,11 @@
 class CimbReader
 {
 public:
-	CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen=false, bool color_correction=true);
-	CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen=false, bool color_correction=true);
+	CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen=false, int color_correction=2);
+	CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen=false, int color_correction=2);
 
 	unsigned read(PositionData& pos);
-	unsigned read_color(const PositionData& pos);
+	unsigned read_color(const PositionData& pos) const;
 	bool done() const;
 
 	void init_ccm(unsigned color_bits, unsigned interleave_blocks, unsigned interleave_partitions, unsigned fountain_blocks);
@@ -31,6 +31,7 @@ protected:
 
 	unsigned _cellSize;
 	FloodDecodePositions _positions;
-	const CimbDecoder& _decoder;
+	CimbDecoder& _decoder;
 	bool _good;
+	int _colorCorrection;
 };

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -6,6 +6,7 @@
 #include "PositionData.h"
 
 #include "bit_file/bitbuffer.h"
+#include "fountain/FountainMetadata.h"
 #include <opencv2/opencv.hpp>
 
 class CimbReader
@@ -18,11 +19,14 @@ public:
 	unsigned read_color(const PositionData& pos);
 	bool done() const;
 
+	void update_metadata(char* buff, unsigned len);
+
 	unsigned num_reads() const;
 
 protected:
 	cv::Mat _image;
 	bitbuffer _grayscale;
+	FountainMetadata _fountainColorHeader;
 
 	unsigned _cellSize;
 	FloodDecodePositions _positions;

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -96,3 +96,8 @@ cv::Mat CimbWriter::image() const
 {
 	return _image;
 }
+
+unsigned CimbWriter::num_cells() const
+{
+	return _positions.count();
+}

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -36,7 +36,7 @@ namespace {
 }
 
 CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int size)
-	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions(symbol_bits+color_bits))
+	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
 	if (size > cimbar::Config::image_size())

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -36,7 +36,7 @@ namespace {
 }
 
 CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int size)
-	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
+	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions(symbol_bits+color_bits))
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
 	if (size > cimbar::Config::image_size())

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -35,9 +35,9 @@ namespace {
 	}
 }
 
-CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, int size)
+CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int size)
 	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
-	, _encoder(symbol_bits, color_bits)
+	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
 	if (size > cimbar::Config::image_size())
 		_offset = (size - cimbar::Config::image_size()) / 2;

--- a/src/lib/cimb_translator/CimbWriter.h
+++ b/src/lib/cimb_translator/CimbWriter.h
@@ -7,7 +7,7 @@
 class CimbWriter
 {
 public:
-	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, int size=0);
+	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1, int size=0);
 
 	bool write(unsigned bits);
 	bool done() const;

--- a/src/lib/cimb_translator/CimbWriter.h
+++ b/src/lib/cimb_translator/CimbWriter.h
@@ -14,6 +14,8 @@ public:
 
 	cv::Mat image() const;
 
+	unsigned num_cells() const;
+
 protected:
 	void paste(const cv::Mat& img, int x, int y);
 

--- a/src/lib/cimb_translator/Common.h
+++ b/src/lib/cimb_translator/Common.h
@@ -10,6 +10,6 @@ namespace cimbar
 
 	cv::Mat load_img(std::string path);
 
-	std::tuple<uchar,uchar,uchar> getColor(unsigned index, unsigned num_colors);
-	cv::Mat getTile(unsigned symbol_bits, unsigned symbol, bool dark=true, unsigned num_colors=4, unsigned color=0);
+	std::tuple<uchar,uchar,uchar> getColor(unsigned index, unsigned num_colors, unsigned color_mode);
+	cv::Mat getTile(unsigned symbol_bits, unsigned symbol, bool dark=true, unsigned num_colors=4, unsigned color=0, unsigned color_mode=1);
 }

--- a/src/lib/cimb_translator/Config.cpp
+++ b/src/lib/cimb_translator/Config.cpp
@@ -32,7 +32,7 @@ unsigned Config::fountain_chunk_size(unsigned ecc, unsigned bitspercell)
 	// this should neatly split into fountain_chunks_per_frame() [ex: 10] chunks per frame.
 	// the other reasonable settings for fountain_chunks_per_frame are `2` and `5`
 	const unsigned eccBlockSize = ecc_block_size();
-	return capacity(bitspercell) * (eccBlockSize-ecc) / eccBlockSize / fountain_chunks_per_frame();
+	return capacity(bitspercell) * (eccBlockSize-ecc) / eccBlockSize / fountain_chunks_per_frame(bitspercell);
 }
 
 }

--- a/src/lib/cimb_translator/Config.cpp
+++ b/src/lib/cimb_translator/Config.cpp
@@ -26,13 +26,13 @@ unsigned Config::corner_padding()
 	return lrint(54.0 / cell_spacing());
 }
 
-unsigned Config::fountain_chunk_size(unsigned ecc, unsigned bitspercell)
+unsigned Config::fountain_chunk_size(unsigned ecc, unsigned bitspercell, bool legacy_mode)
 {
 	// TODO: sanity checks?
 	// this should neatly split into fountain_chunks_per_frame() [ex: 10] chunks per frame.
 	// the other reasonable settings for fountain_chunks_per_frame are `2` and `5`
 	const unsigned eccBlockSize = ecc_block_size();
-	return capacity(bitspercell) * (eccBlockSize-ecc) / eccBlockSize / fountain_chunks_per_frame(bitspercell);
+	return capacity(bitspercell) * (eccBlockSize-ecc) / eccBlockSize / fountain_chunks_per_frame(bitspercell, legacy_mode);
 }
 
 }

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -89,18 +89,17 @@ namespace cimbar
 			return ecc_block_size();
 		}
 
-		static constexpr unsigned interleave_partitions(unsigned bitspercell=0)
+		static constexpr unsigned interleave_partitions()
 		{
-			//return bitspercell;
 			return 2;
 		}
 
-		static constexpr unsigned fountain_chunks_per_frame(unsigned bitspercell=0)
+		static constexpr unsigned fountain_chunks_per_frame(unsigned bitspercell, bool legacy_mode)
 		{
-			return bitspercell << 1;
+			return legacy_mode? 10 : bitspercell << 1;
 		}
 
-		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell);
+		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell, bool legacy_mode);
 
 		static constexpr unsigned compression_level()
 		{

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -16,6 +16,11 @@ namespace cimbar
 			return true;
 		}
 
+		static constexpr unsigned color_mode()
+		{
+			return 1; // unless we override per-thread?
+		}
+
 		static constexpr unsigned color_bits()
 		{
 			return GridConf::color_bits;

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -97,7 +97,7 @@ namespace cimbar
 
 		static constexpr unsigned fountain_chunks_per_frame(unsigned bitspercell=0)
 		{
-			return bitspercell;
+			return bitspercell << 1;
 		}
 
 		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell);

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -89,17 +89,18 @@ namespace cimbar
 			return ecc_block_size();
 		}
 
-		static constexpr unsigned interleave_partitions()
+		static constexpr unsigned interleave_partitions(unsigned bitspercell=0)
 		{
+			//return bitspercell;
 			return 2;
 		}
 
-		static constexpr unsigned fountain_chunks_per_frame()
+		static constexpr unsigned fountain_chunks_per_frame(unsigned bitspercell=0)
 		{
-			return 10;
+			return bitspercell;
 		}
 
-		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell=0);
+		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell);
 
 		static constexpr unsigned compression_level()
 		{

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -133,3 +133,7 @@ int FloodDecodePositions::update(unsigned index, const CellDrift& drift, unsigne
 	return 0;
 }
 
+const CellPositions::positions_list& FloodDecodePositions::positions() const
+{
+	return _positions;
+}

--- a/src/lib/cimb_translator/FloodDecodePositions.h
+++ b/src/lib/cimb_translator/FloodDecodePositions.h
@@ -37,6 +37,8 @@ public:
 	iter next();
 	int update(unsigned index, const CellDrift& drift, unsigned error_distance, uint8_t cooldown);
 
+	const CellPositions::positions_list& positions() const;
+
 protected:
 	int update_adjacents(const std::array<int,4>& adj, const CellDrift& drift, unsigned error_distance, uint8_t cooldown);
 

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -27,5 +27,8 @@ namespace cimbar
 		static constexpr unsigned cell_size = 8;
 		static constexpr unsigned cell_offset = 8;
 		static constexpr unsigned cells_per_col = 112;
+
+		static constexpr int interleave_partitions = 2;
+		static constexpr int fountain_chunks_per_frame = 10;
 	};
 }

--- a/src/lib/cimb_translator/test/CimbDecoderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbDecoderTest.cpp
@@ -79,27 +79,27 @@ TEST_CASE( "CimbDecoderTest/test_get_best_color__dark", "[unit]" )
 	CimbDecoder cd(4, 2);
 
 	// obvious ones
-	assertEquals(2, cd.get_best_color(255, 0, 255));
-	assertEquals(1, cd.get_best_color(255, 255, 0));
-	assertEquals(0, cd.get_best_color(0, 255, 255));
-	assertEquals(3, cd.get_best_color(0, 255, 0));
+	assertEquals(3, cd.get_best_color(255, 0, 255));
+	assertEquals(2, cd.get_best_color(255, 255, 0));
+	assertEquals(1, cd.get_best_color(0, 255, 255));
+	assertEquals(0, cd.get_best_color(0, 255, 0));
 
 	// arbitrary edge cases. We can't really say anything about the value of these colors, but we can at least pick a consistent one
 	assertEquals(0, cd.get_best_color(0, 0, 0));
 	assertEquals(0, cd.get_best_color(70, 70, 70));
 
 	// these we can use!
-	assertEquals(3, cd.get_best_color(20, 200, 20));
-	assertEquals(3, cd.get_best_color(50, 155, 50));
+	assertEquals(0, cd.get_best_color(20, 200, 20));
+	assertEquals(0, cd.get_best_color(50, 155, 50));
 
-	assertEquals(2, cd.get_best_color(200, 30, 200));
-	assertEquals(2, cd.get_best_color(155, 50, 155));
+	assertEquals(3, cd.get_best_color(200, 30, 200));
+	assertEquals(3, cd.get_best_color(155, 50, 155));
 
-	assertEquals(1, cd.get_best_color(200, 155, 20));
-	assertEquals(1, cd.get_best_color(155, 155, 50));
+	assertEquals(2, cd.get_best_color(200, 155, 20));
+	assertEquals(2, cd.get_best_color(155, 155, 50));
 
-	assertEquals(0, cd.get_best_color(50, 155, 200));
-	assertEquals(0, cd.get_best_color(50, 155, 155));
+	assertEquals(1, cd.get_best_color(50, 155, 200));
+	assertEquals(1, cd.get_best_color(50, 155, 155));
 }
 
 TEST_CASE( "CimbDecoderTest/testColorDecode", "[unit]" )

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -140,20 +140,26 @@ TEST_CASE( "CimbReaderTest/testBad", "[unit]" )
 
 TEST_CASE( "CimbReaderTest/testCCM", "[unit]" )
 {
-	cv::Mat sample = TestCimbar::loadSample("6bit/4_30_f0_627_extract.jpg");
+	cv::Mat sample = TestCimbar::loadSample("b/ex2434.jpg");
 
 	TestableCimbDecoder decoder(4, 2);
 	CimbReader cr(sample, decoder);
+
+	// this is the header value for the sample -- we could imitate what the Decoder does
+	// and compute it from the symbols, but that seems like overkill for this test.
+	FountainMetadata md(0, 23586, 7);
+	cr.update_metadata((char*)md.data(), md.md_size);
+	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(6), cimbar::Config::fountain_chunks_per_frame(6));
 
 	assertTrue( decoder._ccm.active() );
 
 	std::stringstream ss;
 	ss << decoder._ccm.mat();
-	assertEquals("[1.5489368, 0.050406694, -0.016417533;\n"
-				 " 0.0055368096, 1.5302141, -0.0011175937;\n"
-				 " 0, 0, 1.4676259]", ss.str());
+	assertEquals("[2.3991191, -0.41846275, -0.54654282;\n "
+				 "-0.42976046, 2.632102, -0.76466882;\n "
+				 "-0.54299992, -0.20199311, 2.2753253]", ss.str());
 
-	std::array<unsigned, 6> expectedColors = {1, 1, 1, 2, 2, 0};
+	std::array<unsigned, 6> expectedColors = {0, 1, 1, 2, 2, 2};
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;
@@ -167,14 +173,14 @@ TEST_CASE( "CimbReaderTest/testCCM", "[unit]" )
 
 TEST_CASE( "CimbReaderTest/testCCM.Disabled", "[unit]" )
 {
-	cv::Mat sample = TestCimbar::loadSample("6bit/4_30_f0_627_extract.jpg");
+	cv::Mat sample = TestCimbar::loadSample("b/ex2434.jpg");
 
 	TestableCimbDecoder decoder(4, 2);
 	CimbReader cr(sample, decoder, false, false);
 
 	assertFalse( decoder._ccm.active() );
 
-	std::array<unsigned, 6> expectedColors = {1, 1, 1, 2, 2, 0};
+	std::array<unsigned, 6> expectedColors = {0, 1, 1, 2, 2, 2};
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;
@@ -188,20 +194,26 @@ TEST_CASE( "CimbReaderTest/testCCM.Disabled", "[unit]" )
 
 TEST_CASE( "CimbReaderTest/testCCM.VeryNecessary", "[unit]" )
 {
-	cv::Mat sample = TestCimbar::loadSample("6bit/4_30_f0_177_ccm.jpg");
+	cv::Mat sample = TestCimbar::loadSample("b/ex380.jpg");
 
 	TestableCimbDecoder decoder(4, 2);
 	CimbReader cr(sample, decoder);
+
+	// this is the header value for the sample -- we could imitate what the Decoder does
+	// and compute it from the symbols, but that seems like overkill for this test.
+	FountainMetadata md(0, 23586, 7);
+	cr.update_metadata((char*)md.data(), md.md_size);
+	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(6), cimbar::Config::fountain_chunks_per_frame(6));
 
 	assertTrue( decoder._ccm.active() );
 
 	std::stringstream ss;
 	ss << decoder._ccm.mat();
-	assertEquals("[1.0675567, 0.21678841, -0.013292357;\n"
-				 " 0.023812667, 0.98703396, -0.0048082001;\n"
-				 " 0, 0, 1.0017186]", ss.str());
+	assertEquals("[1.6250746, 0.0024788622, -0.45772526;\n "
+				 "-0.29126319, 2.2922182, -0.67037439;\n "
+				 "-1.2192062, -2.7447209, 5.0476217]", ss.str());
 
-	std::array<unsigned, 6> expectedColors = {1, 1, 1, 0, 0, 1}; // it's wrong, but it's consistent!
+	std::array<unsigned, 6> expectedColors = {0, 1, 1, 2, 2, 2};
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -47,7 +47,7 @@ TEST_CASE( "CimbReaderTest/testReadOnce", "[unit]" )
 	assertEquals(8, pos.y);
 
 	unsigned color_bits = cr.read_color(pos);
-	assertEquals(0, color_bits);
+	assertEquals(1, color_bits);
 
 	assertFalse(cr.done());
 }
@@ -73,9 +73,9 @@ TEST_CASE( "CimbReaderTest/testSample", "[unit]" )
 		++count;
 	}
 
-	string expected = "0=0 99=8 11680=3 11681=32 11900=28 11901=25 11904=12 11995=2 11996=8 11998=6 "
-			"11999=54 12001=29 12004=6 12099=2 12195=57 12196=1 12200=5 12201=0 12298=32 "
-			"12299=34 12300=30 12399=15";
+	string expected = "0=16 99=24 11680=19 11681=48 11900=44 11901=41 11904=28 11995=18 11996=24 "
+			"11998=22 11999=6 12001=45 12004=22 12099=18 12195=9 12196=17 12200=21 12201=16 "
+			"12298=48 12299=50 12300=46 12399=31";
 	assertEquals( expected, turbo::str::join(res) );
 
 	PositionData pos;
@@ -109,9 +109,9 @@ TEST_CASE( "CimbReaderTest/testSampleMessy", "[unit]" )
 		++count;
 	}
 
-	string expected = "0=0 1=28 99=8 100=28 600=33 601=38 711=30 712=57 11464=53 11576=32 11577=44 "
-			"11687=41 11688=55 11689=32 11690=48 11798=15 11799=25 12297=46 12298=32 "
-			"12299=34 12300=30 12399=15";
+	string expected = "0=16 1=44 99=24 100=44 600=49 601=54 711=46 712=9 11464=5 11576=48 11577=60 "
+			"11687=57 11688=7 11689=48 11690=0 11798=31 11799=41 12297=62 12298=48 12299=50 "
+			"12300=46 12399=31";
 	assertEquals( expected, turbo::str::join(res) );
 
 	PositionData pos;
@@ -153,7 +153,7 @@ TEST_CASE( "CimbReaderTest/testCCM", "[unit]" )
 				 " 0.0055368096, 1.5302141, -0.0011175937;\n"
 				 " 0, 0, 1.4676259]", ss.str());
 
-	std::array<unsigned, 6> expectedColors = {0, 0, 0, 1, 1, 3};
+	std::array<unsigned, 6> expectedColors = {1, 1, 1, 2, 2, 0};
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;
@@ -174,7 +174,7 @@ TEST_CASE( "CimbReaderTest/testCCM.Disabled", "[unit]" )
 
 	assertFalse( decoder._ccm.active() );
 
-	std::array<unsigned, 6> expectedColors = {0, 0, 0, 1, 1, 3};
+	std::array<unsigned, 6> expectedColors = {1, 1, 1, 2, 2, 0};
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;
@@ -201,7 +201,7 @@ TEST_CASE( "CimbReaderTest/testCCM.VeryNecessary", "[unit]" )
 				 " 0.023812667, 0.98703396, -0.0048082001;\n"
 				 " 0, 0, 1.0017186]", ss.str());
 
-	std::array<unsigned, 6> expectedColors = {0, 0, 0, 1, 1, 0}; // it's wrong, but it's consistent!
+	std::array<unsigned, 6> expectedColors = {1, 1, 1, 0, 0, 1}; // it's wrong, but it's consistent!
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -149,7 +149,7 @@ TEST_CASE( "CimbReaderTest/testCCM", "[unit]" )
 	// and compute it from the symbols, but that seems like overkill for this test.
 	FountainMetadata md(0, 23586, 7);
 	cr.update_metadata((char*)md.data(), md.md_size);
-	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(6), cimbar::Config::fountain_chunks_per_frame(6));
+	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(), cimbar::Config::fountain_chunks_per_frame(6, false));
 
 	assertTrue( decoder._ccm.active() );
 
@@ -203,7 +203,7 @@ TEST_CASE( "CimbReaderTest/testCCM.VeryNecessary", "[unit]" )
 	// and compute it from the symbols, but that seems like overkill for this test.
 	FountainMetadata md(0, 23586, 7);
 	cr.update_metadata((char*)md.data(), md.md_size);
-	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(6), cimbar::Config::fountain_chunks_per_frame(6));
+	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(), cimbar::Config::fountain_chunks_per_frame(6, false));
 
 	assertTrue( decoder._ccm.active() );
 

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -201,7 +201,7 @@ TEST_CASE( "CimbReaderTest/testCCM.VeryNecessary", "[unit]" )
 				 " 0.023812667, 0.98703396, -0.0048082001;\n"
 				 " 0, 0, 1.0017186]", ss.str());
 
-	std::array<unsigned, 6> expectedColors = {0, 0, 0, 0, 0, 0}; // it's wrong, but it's consistent!
+	std::array<unsigned, 6> expectedColors = {0, 0, 0, 1, 1, 0}; // it's wrong, but it's consistent!
 	for (unsigned i = 0; i < expectedColors.size(); ++i)
 	{
 		PositionData pos;

--- a/src/lib/cimb_translator/test/CimbWriterTest.cpp
+++ b/src/lib/cimb_translator/test/CimbWriterTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE( "CimbWriterTest/testSimple", "[unit]" )
 
 TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
 {
-	CimbWriter cw(4, 2, true, 1040);
+	CimbWriter cw(4, 2, true, 1, 1040);
 
 	while (1)
 	{

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -72,7 +72,7 @@ int next_frame()
 	// color blocks will contribute to this total, but only symbols used for the initial calculation.
 	// ... this way, if the color decode is failing, we don't get "stuck" rendering a single frame.
 	unsigned required = _fes->blocks_required();
-	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits()))
+	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits(), _legacyMode))
 		required = required*5;
 	if (_fes->block_count() > required)
 	{

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -16,7 +16,7 @@ namespace {
 	std::optional<cv::Mat> _next;
 
 	int _frameCount = 0;
-	uint8_t _encodeId = 0;
+	uint8_t _encodeId = 109;
 
 	// settings
 	unsigned _ecc = cimbar::Config::ecc_bytes();

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -69,7 +69,7 @@ int next_frame()
 
 	// we generate 8x the amount of required blocks -- unless everything fits in a single frame.
 	unsigned required = _fes->blocks_required();
-	if (required > cimbar::Config::fountain_chunks_per_frame())
+	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits()+_colorBits))
 		required = required*8;
 	if (_fes->block_count() > required)
 	{

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -69,8 +69,8 @@ int next_frame()
 		return 0;
 
 	// we generate 5x the amount of required symbol blocks -- unless everything fits in a single frame.
-	// color blocks will contribute to this total, but only symbols used for the initial calculation.
-	// ... this way, if the color decode is failing, we don't get "stuck" rendering a single frame.
+	// color blocks will contribute to this total, but only symbols are used for the initial calculation.
+	// ... this way, if the color decode is failing, it won't get "stuck" failing to read a single frame.
 	unsigned required = _fes->blocks_required();
 	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits(), _legacyMode))
 		required = required*5;

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -67,10 +67,12 @@ int next_frame()
 	if (!_window or !_fes)
 		return 0;
 
-	// we generate 8x the amount of required blocks -- unless everything fits in a single frame.
+	// we generate 5x the amount of required symbol blocks -- unless everything fits in a single frame.
+	// color blocks will contribute to this total, but only symbols used for the initial calculation.
+	// ... this way, if the color decode is failing, we don't get "stuck" rendering a single frame.
 	unsigned required = _fes->blocks_required();
-	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits()+_colorBits))
-		required = required*8;
+	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits()))
+		required = required*5;
 	if (_fes->block_count() > required)
 	{
 		_fes->restart();

--- a/src/lib/cimbar_js/cimbar_js.h
+++ b/src/lib/cimbar_js/cimbar_js.h
@@ -10,7 +10,7 @@ int initialize_GL(int width, int height);
 int render();
 int next_frame();
 int encode(unsigned char* buffer, unsigned size, int encode_id);  // encode_id == -1 -> auto-increment
-int configure(unsigned color_bits, unsigned ecc, int compression);
+int configure(unsigned color_bits, unsigned ecc, int compression, bool legacy_mode);
 
 #ifdef __cplusplus
 }

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -111,6 +111,7 @@ inline unsigned Decoder::decode(const MAT& img, STREAM& ostream, bool should_pre
 template <typename MAT, typename FOUNTAINSTREAM>
 inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream, bool should_preprocess, bool color_correction)
 {
+	// reader takes cimbar::Config::color_mode() ?
 	CimbReader reader(img, _decoder, should_preprocess, color_correction);
 
 	aligned_stream aligner(ostream, ostream.chunk_size());

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -160,13 +160,6 @@ inline unsigned Decoder::do_decode_coupled(CimbReader& reader, STREAM& ostream)
 	return bb.flush(rss);
 }
 
-
-// seems like we want to take a file or img, and have an output sink
-// output sync could be template param?
-// we'd decode the full message (via bit_writer) to a temp buffer -- probably a stringstream
-// then we'd direct the stringstream to our sink
-// which would either be a filestream, or a multi-channel fountain sink
-
 template <typename MAT, typename STREAM>
 inline unsigned Decoder::decode(const MAT& img, STREAM& ostream, bool should_preprocess, int color_correction)
 {
@@ -177,15 +170,7 @@ inline unsigned Decoder::decode(const MAT& img, STREAM& ostream, bool should_pre
 template <typename MAT, typename FOUNTAINSTREAM>
 inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream, bool should_preprocess, int color_correction)
 {
-	// reader takes cimbar::Config::color_mode() ?
 	CimbReader reader(img, _decoder, should_preprocess, color_correction);
-
-	// maybe give aligned_stream a callback function that can poke the CimbReader on flush()?
-	// and then in do_decode(), after the first flush, call CimbReader::try_to_make_new_ccm(),
-	//  ... maybe a replacement for the existing updateColorCorrection()? (called in constructor, would now happen later)...
-	// which reads the values from the image (using what the aligned_stream gave it -- if anything, and maybe the cellpositions from FloodFillDecode?)
-	// iff we got enough data from aligned_stream to sample enough colors, try_to_make_new_ccm() pushes the updated ccm to CimbDecoder's threadlocal
-	// if not, we use whatever we previously had in CimbDecoder's threadlocal...?
 	aligned_stream aligner(ostream, ostream.chunk_size(), 0, std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2));
 	return do_decode(reader, aligner);
 }

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -42,6 +42,7 @@ protected:
 	unsigned _colorBits;
 	unsigned _bitsPerOp;
 	bool _coupled;
+	unsigned _colorMode;
 	unsigned _interleaveBlocks;
 	unsigned _interleavePartitions;
 	CimbDecoder _decoder;
@@ -53,8 +54,9 @@ inline Decoder::Decoder(int ecc_bytes, int color_bits, unsigned color_mode, bool
 	, _colorBits(color_bits >= 0? color_bits : cimbar::Config::color_bits())
 	, _bitsPerOp(cimbar::Config::symbol_bits() + _colorBits)
 	, _coupled(coupled)
+	, _colorMode(color_mode)
 	, _interleaveBlocks(interleave? cimbar::Config::interleave_blocks() : 0)
-	, _interleavePartitions(cimbar::Config::interleave_partitions(_bitsPerOp))
+	, _interleavePartitions(cimbar::Config::interleave_partitions())
 	, _decoder(cimbar::Config::symbol_bits(), _colorBits, color_mode, cimbar::Config::dark(), 0xFF)
 {
 }
@@ -107,7 +109,7 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 	}
 
 	// do color correction init, now that we (hopefully) have some fountain headers from the symbol decode
-	reader.init_ccm(_colorBits, _interleaveBlocks, _interleavePartitions, cimbar::Config::fountain_chunks_per_frame(_bitsPerOp));
+	reader.init_ccm(_colorBits, _interleaveBlocks, _interleavePartitions, cimbar::Config::fountain_chunks_per_frame(_bitsPerOp, _coupled and _colorMode==0));
 
 	bitbuffer colorBits(cimbar::Config::capacity(_colorBits));
 	// then decode colors.

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -98,7 +98,7 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 	}
 
 	// do color correction init, now that we (hopefully) have some fountain headers from the symbol decode
-	reader.init_ccm();
+	reader.init_ccm(_colorBits, _interleaveBlocks, _interleavePartitions, cimbar::Config::fountain_chunks_per_frame(_bitsPerOp));
 
 	bitbuffer colorBits(cimbar::Config::capacity(_colorBits));
 	// then decode colors.

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -44,7 +44,7 @@ inline Decoder::Decoder(int ecc_bytes, int color_bits, bool interleave)
 	, _colorBits(color_bits >= 0? color_bits : cimbar::Config::color_bits())
 	, _bitsPerOp(cimbar::Config::symbol_bits() + _colorBits)
 	, _interleaveBlocks(interleave? cimbar::Config::interleave_blocks() : 0)
-	, _interleavePartitions(cimbar::Config::interleave_partitions())
+	, _interleavePartitions(cimbar::Config::interleave_partitions(_bitsPerOp))
 	, _decoder(cimbar::Config::symbol_bits(), _colorBits, cimbar::Config::dark(), 0xFF)
 {
 }

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -95,11 +95,10 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 		// flush symbols
 		reed_solomon_stream rss(ostream, _eccBytes, _eccBlockSize);
 		symbolBits.flush(rss);
-
-		// TODO: get fountain headers out of ostream somehow.
-		// after we call symbolBits.flush(), the underlying aligned stream (ostream) may have knowledge about
-		// the fountain headers -- one per chunk (see chunk_size()) -- which we can use to help us with the color decode...
 	}
+
+	// do color correction init, now that we (hopefully) have some fountain headers from the symbol decode
+	reader.init_ccm();
 
 	bitbuffer colorBits(cimbar::Config::capacity(_colorBits));
 	// then decode colors.

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -72,8 +72,6 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 	colorPositions.resize(reader.num_reads()); // the number of cells == reader.num_reads(). Can we calculate this from config at compile time? Do we care?
 
 	unsigned bitsPerSymbol = cimbar::Config::symbol_bits();
-	unsigned maxSymbolBit = reader.num_reads() * bitsPerSymbol;
-
 	unsigned bytesDecoded = 0;
 	{
 		bitbuffer symbolBits(cimbar::Config::capacity(bitsPerSymbol));

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -48,7 +48,9 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 
 	// ex: with ecc = 30 and 155 byte blocks, we have 60 rs blocks * 125 bytes per block == 7500 bytes to work with.
 	// if fountain_chunks_per_frame() is 10, the fountain_chunk_size will be 750.
-	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol+_bitsPerColor);
+	// we calculate requiredFrames based only on symbol bits, to avoid the situation where the color decode is failing while we're
+	// refusing to generate additional frames...
+	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol);
 	if (requiredFrames == 0)
 		requiredFrames = 1;
 

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -15,8 +15,8 @@ public:
 	using SimpleEncoder::SimpleEncoder;
 
 	unsigned encode(const std::string& filename, std::string output_prefix);
-	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=6, double redundancy=1.2, int canvas_size=0);
-	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=6, double redundancy=4.0, int canvas_size=0);
+	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=16, double redundancy=1.2, int canvas_size=0);
+	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=16, double redundancy=4.0, int canvas_size=0);
 };
 
 inline unsigned Encoder::encode(const std::string& filename, std::string output_prefix)
@@ -46,9 +46,8 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	if (!fes)
 		return 0;
 
-	// With ecc = 40, we have 60 rs blocks * 115 bytes per block == 6900 bytes to work with.
-	// the fountain_chunk_size will be 690.
-	// fountain_chunks_per_frame() is currently a constant (10).
+	// ex: with ecc = 30 and 155 byte blocks, we have 60 rs blocks * 125 bytes per block == 7500 bytes to work with.
+	// if fountain_chunks_per_frame() is 10, the fountain_chunk_size will be 750.
 	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol+_bitsPerColor);
 	if (requiredFrames == 0)
 		requiredFrames = 1;

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -50,7 +50,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	// if fountain_chunks_per_frame() is 10, the fountain_chunk_size will be 750.
 	// we calculate requiredFrames based only on symbol bits, to avoid the situation where the color decode is failing while we're
 	// refusing to generate additional frames...
-	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol);
+	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol, _coupled and _colorMode==0);
 	if (requiredFrames == 0)
 		requiredFrames = 1;
 

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -49,7 +49,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	// With ecc = 40, we have 60 rs blocks * 115 bytes per block == 6900 bytes to work with.
 	// the fountain_chunk_size will be 690.
 	// fountain_chunks_per_frame() is currently a constant (10).
-	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame();
+	unsigned requiredFrames = fes->blocks_required() * redundancy / cimbar::Config::fountain_chunks_per_frame(_bitsPerSymbol+_bitsPerColor);
 	if (requiredFrames == 0)
 		requiredFrames = 1;
 

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -30,6 +30,7 @@ protected:
 	unsigned _bitsPerSymbol;
 	unsigned _bitsPerColor;
 	bool _dark;
+	unsigned _colorMode;
 	uint8_t _encodeId = 0;
 };
 
@@ -39,6 +40,7 @@ inline SimpleEncoder::SimpleEncoder(int ecc_bytes, unsigned bits_per_symbol, int
 	, _bitsPerSymbol(bits_per_symbol? bits_per_symbol : cimbar::Config::symbol_bits())
 	, _bitsPerColor(bits_per_color >= 0? bits_per_color : cimbar::Config::color_bits())
 	, _dark(cimbar::Config::dark())
+	, _colorMode(cimbar::Config::color_mode())
 {
 }
 
@@ -66,7 +68,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int can
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, canvas_size);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_size);
 
 	reed_solomon_stream rss(stream, _eccBytes, _eccBlockSize);
 	bitreader br;

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -19,6 +19,7 @@ class SimpleEncoder
 {
 public:
 	SimpleEncoder(int ecc_bytes=-1, unsigned bits_per_symbol=0, int bits_per_color=-1);
+	void set_legacy_mode();
 	void set_encode_id(uint8_t encode_id); // [0-127] -- the high bit is ignored.
 
 	template <typename STREAM>
@@ -28,11 +29,16 @@ public:
 	fountain_encoder_stream::ptr create_fountain_encoder(STREAM& stream, int compression_level=6);
 
 protected:
+	template <typename STREAM>
+	std::optional<cv::Mat> encode_next_coupled(STREAM& stream, int canvas_size=0);
+
+protected:
 	unsigned _eccBytes;
 	unsigned _eccBlockSize;
 	unsigned _bitsPerSymbol;
 	unsigned _bitsPerColor;
 	bool _dark;
+	bool _coupled;
 	unsigned _colorMode;
 	uint8_t _encodeId = 0;
 };
@@ -43,8 +49,15 @@ inline SimpleEncoder::SimpleEncoder(int ecc_bytes, unsigned bits_per_symbol, int
 	, _bitsPerSymbol(bits_per_symbol? bits_per_symbol : cimbar::Config::symbol_bits())
 	, _bitsPerColor(bits_per_color >= 0? bits_per_color : cimbar::Config::color_bits())
 	, _dark(cimbar::Config::dark())
+	, _coupled(true)
 	, _colorMode(cimbar::Config::color_mode())
 {
+}
+
+inline void SimpleEncoder::set_legacy_mode()
+{
+	_coupled = false;
+	_colorMode = 0;
 }
 
 inline void SimpleEncoder::set_encode_id(uint8_t encode_id)
@@ -52,21 +65,12 @@ inline void SimpleEncoder::set_encode_id(uint8_t encode_id)
 	_encodeId = encode_id;
 }
 
-/* while bits == f.read(buffer, 8192)
- *     encode(bits)
- *
- * char buffer[2000];
- * while f.read(buffer)
- *     bit_buffer bb(buffer)
- *     while bb
- *         bits1 = bb.get(_bitsPerSymbol)
- *         bits2 = bb.get(_bitsPerColor)
- *
- * */
-
 template <typename STREAM>
 inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int canvas_size)
 {
+	if (!_coupled)
+		return encode_next_coupled(stream, canvas_size);
+
 	if (!stream.good())
 		return std::nullopt;
 
@@ -103,7 +107,8 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int can
 
 			if (bitPos >= endBitPos)
 			{
-				bitsPerRead = _bitsPerColor; // switch to color mode
+				// switch to color section
+				bitsPerRead = _bitsPerColor;
 				bitsPerWrite = _bitsPerColor;
 				bitPos = 0;
 				++progress;
@@ -120,6 +125,41 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int can
 	}
 
 	// return what we've got
+	return writer.image();
+}
+
+template <typename STREAM>
+inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream, int canvas_size)
+{
+	// the old way. Symbol and color bits are mixed together, limiting the color correction possibilities
+	// but potentially allowing a lack of errors in one channel to correct errors in the other.
+	// ... also, potentially allowing a preponderance of errors in one channel to doom the whole decode.
+	// the net result is that best case performance *can* be better this way, but average and worst case
+	// will be worse.
+	if (!stream.good())
+		return std::nullopt;
+
+	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, canvas_size);
+
+	reed_solomon_stream rss(stream, _eccBytes, _eccBlockSize);
+	bitreader br;
+	while (rss.good())
+	{
+		unsigned bytes = rss.readsome();
+		if (bytes == 0)
+			break;
+		br.assign_new_buffer(rss.buffer(), bytes);
+		while (!br.empty())
+		{
+			unsigned bits = br.read(bits_per_op);
+			if (!br.partial())
+				writer.write(bits);
+		}
+		if (writer.done())
+			return writer.image();
+	}
+	// we don't have a full frame, but return what we've got
 	return writer.image();
 }
 

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -49,14 +49,14 @@ inline SimpleEncoder::SimpleEncoder(int ecc_bytes, unsigned bits_per_symbol, int
 	, _bitsPerSymbol(bits_per_symbol? bits_per_symbol : cimbar::Config::symbol_bits())
 	, _bitsPerColor(bits_per_color >= 0? bits_per_color : cimbar::Config::color_bits())
 	, _dark(cimbar::Config::dark())
-	, _coupled(true)
+	, _coupled(false)
 	, _colorMode(cimbar::Config::color_mode())
 {
 }
 
 inline void SimpleEncoder::set_legacy_mode()
 {
-	_coupled = false;
+	_coupled = true;
 	_colorMode = 0;
 }
 
@@ -68,7 +68,7 @@ inline void SimpleEncoder::set_encode_id(uint8_t encode_id)
 template <typename STREAM>
 inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int canvas_size)
 {
-	if (!_coupled)
+	if (_coupled)
 		return encode_next_coupled(stream, canvas_size);
 
 	if (!stream.good())
@@ -166,7 +166,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream,
 template <typename STREAM>
 inline fountain_encoder_stream::ptr SimpleEncoder::create_fountain_encoder(STREAM& stream, int compression_level)
 {
-	unsigned chunk_size = cimbar::Config::fountain_chunk_size(_eccBytes, _bitsPerColor + _bitsPerSymbol);
+	unsigned chunk_size = cimbar::Config::fountain_chunk_size(_eccBytes, _bitsPerColor + _bitsPerSymbol, (_colorMode==0 and _coupled));
 
 	std::stringstream ss;
 	if (compression_level <= 0)

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -140,7 +140,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream,
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, canvas_size);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_size);
 
 	reed_solomon_stream rss(stream, _eccBytes, _eccBlockSize);
 	bitreader br;

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -13,8 +13,6 @@
 #include <optional>
 #include <string>
 
-#include <iostream>
-
 class SimpleEncoder
 {
 public:

--- a/src/lib/encoder/test/DecoderTest.cpp
+++ b/src/lib/encoder/test/DecoderTest.cpp
@@ -28,10 +28,10 @@ TEST_CASE( "DecoderTest/testDecode", "[unit]" )
 
 	Decoder dec(0);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
-	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("b/tr_0.png"), decodedFile);
 	assertEquals( 9300, bytesDecoded );
 
-	assertEquals( "7e1919b1210ccc332fc56e8b35cccd622d980f03c6c3b32338bb00aa4b6a22a2", get_hash(decodedFile) );
+	assertEquals( "ddcb6cd47751df1402dcf2cffdace212bc9e4a4b6ef097ad4828913086309469", get_hash(decodedFile) );
 }
 
 TEST_CASE( "DecoderTest/testDecodeEcc", "[unit]" )
@@ -40,10 +40,10 @@ TEST_CASE( "DecoderTest/testDecodeEcc", "[unit]" )
 
 	Decoder dec(30);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
-	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("b/tr_0.png"), decodedFile);
 	assertEquals( 7500, bytesDecoded );
 
-	assertEquals( "382c76644a4dff475c5793c5fe061e35e47be252010d29aeaf8d93ee6a3f7045", get_hash(decodedFile) );
+	assertEquals( "a0e9fff8cd5b13807fae215b8b07e38091d3f533ff46243b53ee7f74fbbee0d5", get_hash(decodedFile) );
 }
 
 TEST_CASE( "DecoderTest/testDecode.Sample", "[unit]" )
@@ -52,6 +52,45 @@ TEST_CASE( "DecoderTest/testDecode.Sample", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	Decoder dec(0);
+	std::string decodedFile = tempdir.path() / "testDecode.txt";
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("b/scan2434.jpg"), decodedFile);
+	assertEquals( 9300, bytesDecoded );
+
+	if (CV_VERSION_MAJOR == 4)
+		assertEquals( "ccb39ac3511a8974a8e98d3ea321d576d974d28f0b9373fc611ce6a4c83b561c", get_hash(decodedFile) );
+}
+
+TEST_CASE( "DecoderTest/testDecode.4c", "[unit]" )
+{
+	// legacy format
+	MakeTempDirectory tempdir;
+
+	Decoder dec(0, 2, 0, true);
+	std::string decodedFile = tempdir.path() / "testDecode.txt";
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	assertEquals( 9300, bytesDecoded );
+
+	assertEquals( "7e1919b1210ccc332fc56e8b35cccd622d980f03c6c3b32338bb00aa4b6a22a2", get_hash(decodedFile) );
+}
+
+TEST_CASE( "DecoderTest/testDecodeEcc.4c", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+
+	Decoder dec(30, 2, 0, true);
+	std::string decodedFile = tempdir.path() / "testDecode.txt";
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	assertEquals( 7500, bytesDecoded );
+
+	assertEquals( "382c76644a4dff475c5793c5fe061e35e47be252010d29aeaf8d93ee6a3f7045", get_hash(decodedFile) );
+}
+
+TEST_CASE( "DecoderTest/testDecode.Sample4c", "[unit]" )
+{
+	// regression test -- useful for now, but is very brittle
+	MakeTempDirectory tempdir;
+
+	Decoder dec(0, 2, 0, true);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
 	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4_30_f0_627_extract.jpg"), decodedFile);
 	assertEquals( 9300, bytesDecoded );

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -39,7 +39,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 
 	// decoder
 	Decoder dec(30);
-	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30));
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6));
 
 	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 	assertEquals( 7500, bytesDecoded );
@@ -63,7 +63,7 @@ TEST_CASE( "EncoderRoundTripTest/testStreaming", "[unit]" )
 
 	// create decoder
 	Decoder dec(30);
-	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30));
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6));
 
 	// encode frames, then pass to decoder
 	for (int i = 0; i < 100; ++i)

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -39,7 +39,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 
 	// decoder
 	Decoder dec(30);
-	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6));
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6, false));
 
 	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 	assertEquals( 7500, bytesDecoded );
@@ -63,7 +63,7 @@ TEST_CASE( "EncoderRoundTripTest/testStreaming", "[unit]" )
 
 	// create decoder
 	Decoder dec(30);
-	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6));
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6, false));
 
 	// encode frames, then pass to decoder
 	for (int i = 0; i < 100; ++i)

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -31,7 +31,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xaecc8c00efce8c28;
+	uint64_t hash = 0xeecc8800efce8c48;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat encodedImg = cv::imread(path);
 	cv::cvtColor(encodedImg, encodedImg, cv::COLOR_BGR2RGB);
@@ -44,7 +44,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 	assertEquals( 7500, bytesDecoded );
 
-	std::string decodedContents = File(tempdir.path() / "0.751").read_all();
+	std::string decodedContents = File(tempdir.path() / "0.626").read_all();
 	assertEquals( "hello", decodedContents );
 }
 

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -38,7 +38,30 @@ TEST_CASE( "EncoderTest/testVanilla", "[unit]" )
 	}
 }
 
-TEST_CASE( "EncoderTest/testFountain", "[unit]" )
+TEST_CASE( "EncoderTest/testFountain.4c", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+
+	std::string inputFile = TestCimbar::getProjectDir() + "/LICENSE";
+	std::string outPrefix = tempdir.path() / "encoder.fountain";
+
+	Encoder enc(40, 4, 2);
+	enc.set_legacy_mode();
+	assertEquals( 4, enc.encode_fountain(inputFile, outPrefix, 0) );
+
+	std::vector<uint64_t> hashes = {0x3f16ce63e424b9e2, 0x8f809de57607a92b, 0xb8d41fc26c0ca107, 0xb84c6d8ac21d6a43};
+	for (unsigned i = 0; i < hashes.size(); ++i)
+	{
+		DYNAMIC_SECTION( "are we correct? : " << i )
+		{
+			std::string path = fmt::format("{}_{}.png", outPrefix, i);
+			cv::Mat img = cv::imread(path);
+			assertEquals( hashes[i], image_hash::average_hash(img) );
+		}
+	}
+}
+
+TEST_CASE( "EncoderTest/testFountain.B", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
@@ -48,7 +71,7 @@ TEST_CASE( "EncoderTest/testFountain", "[unit]" )
 	Encoder enc(40, 4, 2);
 	assertEquals( 4, enc.encode_fountain(inputFile, outPrefix, 0) );
 
-	std::vector<uint64_t> hashes = {0xcf09eb067c876ea6, 0x4697a76025a40c43, 0x666aaca0ec8d6d43, 0xcf09eb067c876ea6};
+	std::vector<uint64_t> hashes = {0xcf09eb067c876ea6, 0x4697a76025a40c43, 0x666aaca0ec8d6d43, 0xe6e44ca8ec33a260};
 	for (unsigned i = 0; i < hashes.size(); ++i)
 	{
 		DYNAMIC_SECTION( "are we correct? : " << i )

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -47,9 +47,9 @@ TEST_CASE( "EncoderTest/testFountain.4c", "[unit]" )
 
 	Encoder enc(40, 4, 2);
 	enc.set_legacy_mode();
-	assertEquals( 4, enc.encode_fountain(inputFile, outPrefix, 0) );
+	assertEquals( 3, enc.encode_fountain(inputFile, outPrefix, 0) );
 
-	std::vector<uint64_t> hashes = {0x3f16ce63e424b9e2, 0x8f809de57607a92b, 0xb8d41fc26c0ca107, 0xb84c6d8ac21d6a43};
+	std::vector<uint64_t> hashes = {0xbb1cc62b662abfe5, 0xf586f6466a5b194, 0x8c2f0f40e6ecb08b};
 	for (unsigned i = 0; i < hashes.size(); ++i)
 	{
 		DYNAMIC_SECTION( "are we correct? : " << i )

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "EncoderTest/testVanilla", "[unit]" )
 	Encoder enc(40, 4, 2);
 	assertEquals( 3, enc.encode(inputFile, outPrefix) );
 
-	std::vector<uint64_t> hashes = {0xc47ced006f253562, 0x2d8cc44256ccb9eb, 0x6ed0efb800000000};
+	std::vector<uint64_t> hashes = {0xe727a520684bccec, 0x46a06f002dcded87, 0x4eb1e3646fce8c08};
 	for (unsigned i = 0; i < hashes.size(); ++i)
 	{
 		DYNAMIC_SECTION( "are we correct? : " << i )
@@ -46,9 +46,9 @@ TEST_CASE( "EncoderTest/testFountain", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	Encoder enc(40, 4, 2);
-	assertEquals( 3, enc.encode_fountain(inputFile, outPrefix, 0) );
+	assertEquals( 4, enc.encode_fountain(inputFile, outPrefix, 0) );
 
-	std::vector<uint64_t> hashes = {0xbb1cc62b662abfe5, 0xf586f6466a5b194, 0x8c2f0f40e6ecb08b};
+	std::vector<uint64_t> hashes = {0xcf09eb067c876ea6, 0x4697a76025a40c43, 0x666aaca0ec8d6d43, 0xcf09eb067c876ea6};
 	for (unsigned i = 0; i < hashes.size(); ++i)
 	{
 		DYNAMIC_SECTION( "are we correct? : " << i )
@@ -70,7 +70,7 @@ TEST_CASE( "EncoderTest/testFountain.Compress", "[unit]" )
 	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0x664598a460acad14;
+	uint64_t hash = 0xb36b65402eec434e;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
 	assertEquals( hash, image_hash::average_hash(img) );
@@ -96,7 +96,7 @@ TEST_CASE( "EncoderTest/testPiecemealFountainEncoder", "[unit]" )
 	std::optional<cv::Mat> frame = enc.encode_next(*fes);
 	assertTrue( frame );
 
-	uint64_t hash = 0x423de068e4894a7f;
+	uint64_t hash = 0xa810f60b46fb87b9;
 	assertEquals( hash, image_hash::average_hash(*frame) );
 }
 
@@ -108,9 +108,9 @@ TEST_CASE( "EncoderTest/testFountain.Size", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	Encoder enc(30, 4, 2);
-	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 10, 2.0, 1080) );
+	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6, 1080) );
 
-	uint64_t hash = 0xeb28da8af88de8d0;
+	uint64_t hash = 0xbdc232c714226fe6;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
 	assertEquals( 1080, img.rows );

--- a/src/lib/fountain/FountainMetadata.h
+++ b/src/lib/fountain/FountainMetadata.h
@@ -47,7 +47,7 @@ public:
 
 	uint32_t id() const
 	{
-		uint32_t shortid;
+		uint32_t shortid = 0;
 		std::copy(data(), data()+4, reinterpret_cast<uint8_t*>(&shortid));
 		return shortid;
 	}

--- a/src/lib/fountain/FountainMetadata.h
+++ b/src/lib/fountain/FountainMetadata.h
@@ -1,46 +1,62 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #pragma once
 
+#include <array>
+
 class FountainMetadata
 {
 public:
-	static const unsigned md_size = 4;
+	static const unsigned md_size = 6;
 
-	static void to_uint8_arr(uint8_t encode_id, unsigned size, uint8_t* arr)
+	static void to_uint8_arr(uint8_t encode_id, unsigned size, uint16_t block_id, uint8_t* arr)
 	{
 		arr[0] = (encode_id & 0x7F) | ((size >> 17) & 0x80);
 		arr[1] = (size >> 16) & 0xFF;
 		arr[2] = (size >> 8) & 0xFF;
 		arr[3] = size & 0xFF;
+		arr[4] = (block_id >> 8) & 0xFF;
+		arr[5] = block_id & 0xFF;
 	}
 
 public:
 	FountainMetadata(uint32_t id)
-	    : _data(id)
 	{
+		uint8_t* d = data();
+		std::copy(reinterpret_cast<uint8_t*>(&id), reinterpret_cast<uint8_t*>(&id)+4, d);
+		d[4] = d[5] = 0;
 	}
 
-	FountainMetadata(const char* buff, unsigned len)
+	explicit FountainMetadata(const char* buff, unsigned len)
 	{
 		if (len > md_size)
 			len = md_size;
 		std::copy(buff, buff+len, data());
 	}
 
-	FountainMetadata(uint8_t encode_id, unsigned size)
+	FountainMetadata(uint8_t encode_id, unsigned size, uint16_t block_id)
 	{
 		uint8_t* d = data();
-		to_uint8_arr(encode_id, size, d);
+		to_uint8_arr(encode_id, size, block_id, d);
 	}
 
 	uint32_t id() const
 	{
-		return _data;
+		uint32_t shortid;
+		std::copy(data(), data()+4, reinterpret_cast<uint8_t*>(&shortid));
+		return shortid;
 	}
 
 	uint8_t encode_id() const
 	{
 		return data()[0] & 0x7F;
+	}
+
+	uint16_t block_id() const
+	{
+		const uint8_t* d = data()+4;
+		uint16_t res = d[1];
+		res |= ((uint16_t)d[0] << 8);
+		return res;
 	}
 
 	unsigned file_size() const
@@ -56,14 +72,14 @@ public:
 protected:
 	uint8_t* data()
 	{
-		return reinterpret_cast<uint8_t*>(&_data);
+		return _data.data();
 	}
 
 	const uint8_t* data() const
 	{
-		return reinterpret_cast<const uint8_t*>(&_data);
+		return const_cast<const uint8_t*>(_data.data());
 	}
 
 protected:
-	uint32_t _data; // might invert this and only generate the uint32_t when we need it
+	std::array<uint8_t, 6> _data;
 };

--- a/src/lib/fountain/FountainMetadata.h
+++ b/src/lib/fountain/FountainMetadata.h
@@ -27,7 +27,7 @@ public:
 public:
 	FountainMetadata(uint32_t id)
 	{
-		uint8_t* d = data();
+		uint8_t* d = _data.data();
 		std::copy(reinterpret_cast<uint8_t*>(&id), reinterpret_cast<uint8_t*>(&id)+4, d);
 		d[4] = d[5] = 0;
 	}
@@ -36,12 +36,12 @@ public:
 	{
 		if (len > md_size)
 			len = md_size;
-		std::copy(buff, buff+len, data());
+		std::copy(buff, buff+len, _data.data());
 	}
 
 	FountainMetadata(uint8_t encode_id, unsigned size, uint16_t block_id)
 	{
-		uint8_t* d = data();
+		uint8_t* d = _data.data();
 		to_uint8_arr(encode_id, size, block_id, d);
 	}
 
@@ -67,7 +67,7 @@ public:
 
 	void increment_block_id()
 	{
-		update_block_id_internal(block_id()+1, data()+4);
+		update_block_id_internal(block_id()+1, _data.data()+4);
 	}
 
 	unsigned file_size() const
@@ -78,12 +78,6 @@ public:
 		res |= ((uint32_t)d[1] << 16);
 		res |= ((uint32_t)d[0] & 0x80) << 17;
 		return res;
-	}
-
-protected:
-	uint8_t* data()
-	{
-		return _data.data();
 	}
 
 	const uint8_t* data() const

--- a/src/lib/fountain/FountainMetadata.h
+++ b/src/lib/fountain/FountainMetadata.h
@@ -5,6 +5,13 @@
 
 class FountainMetadata
 {
+protected:
+	static void update_block_id_internal(uint16_t block_id, uint8_t* arr)
+	{
+		arr[0] = (block_id >> 8) & 0xFF;
+		arr[1] = block_id & 0xFF;
+	}
+
 public:
 	static const unsigned md_size = 6;
 
@@ -14,8 +21,7 @@ public:
 		arr[1] = (size >> 16) & 0xFF;
 		arr[2] = (size >> 8) & 0xFF;
 		arr[3] = size & 0xFF;
-		arr[4] = (block_id >> 8) & 0xFF;
-		arr[5] = block_id & 0xFF;
+		update_block_id_internal(block_id, arr+4);
 	}
 
 public:
@@ -57,6 +63,11 @@ public:
 		uint16_t res = d[1];
 		res |= ((uint16_t)d[0] << 8);
 		return res;
+	}
+
+	void increment_block_id()
+	{
+		update_block_id_internal(block_id()+1, data()+4);
 	}
 
 	unsigned file_size() const

--- a/src/lib/fountain/fountain_encoder_stream.h
+++ b/src/lib/fountain/fountain_encoder_stream.h
@@ -18,10 +18,10 @@ protected:
 
 protected:
 	fountain_encoder_stream(std::string&& data, unsigned buffer_size, uint8_t encode_id)
-	    : _data(data)
-	    , _buffer(buffer_size, 0)
-	    , _encodeId(encode_id)
-	    , _encoder((uint8_t*)_data.data(), _data.size(), block_size())
+		: _data(data)
+		, _buffer(buffer_size, 0)
+		, _encodeId(encode_id)
+		, _encoder((uint8_t*)_data.data(), _data.size(), block_size())
 	{
 	}
 
@@ -83,13 +83,9 @@ public:
 		if (res != block_size())
 			_encoder.encode(_block++, data, block_size()); // try twice -- the last initial block will be the wrong size
 
-		// write first 4 bytes of header
-		FountainMetadata::to_uint8_arr(_encodeId, _data.size(), _buffer.data());
-
-		// last 2 bytes of header
 		unsigned block = _block - 1; // we already incremented it above
-		_buffer.data()[4] = (block >> 8) & 0xFF;
-		_buffer.data()[5] = block & 0xFF;
+		// write header
+		FountainMetadata::to_uint8_arr(_encodeId, _data.size(), block, _buffer.data());
 		_buffIndex = 0;
 	}
 

--- a/src/lib/fountain/test/FountainMetadataTest.cpp
+++ b/src/lib/fountain/test/FountainMetadataTest.cpp
@@ -36,7 +36,7 @@ TEST_CASE( "FountainMetadataTest/testFromBytes.BigFile", "[unit]" )
 
 TEST_CASE( "FountainMetadataTest/testThings", "[unit]" )
 {
-	FountainMetadata inmd(0_uchar, 0xd0731f);
+	FountainMetadata inmd(0_uchar, 0xd0731f, 0U);
 	assertEquals( 0, inmd.encode_id() );
 	assertEquals( 0xd0731f, inmd.file_size() );
 
@@ -47,7 +47,7 @@ TEST_CASE( "FountainMetadataTest/testThings", "[unit]" )
 
 TEST_CASE( "FountainMetadataTest/testIgnoreTopEncodeIdBit", "[unit]" )
 {
-	FountainMetadata inmd(250_uchar, 0xFFFFFF);
+	FountainMetadata inmd(250_uchar, 0xFFFFFF, 0U);
 	assertEquals( 122, static_cast<unsigned>(inmd.encode_id()) );
 	assertEquals( 0xFFFFFF, inmd.file_size() );
 
@@ -58,7 +58,7 @@ TEST_CASE( "FountainMetadataTest/testIgnoreTopEncodeIdBit", "[unit]" )
 
 TEST_CASE( "FountainMetadataTest/testBigFile", "[unit]" )
 {
-	FountainMetadata inmd(2_uchar, 0x1FFFFFF);
+	FountainMetadata inmd(2_uchar, 0x1FFFFFF, 0U);
 	assertEquals( 2, static_cast<unsigned>(inmd.encode_id()) );
 	assertEquals( 0x1FFFFFF, inmd.file_size() );
 

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -68,7 +68,7 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 
 	string frame2 = createFrame(1, 1600);
 	assertEquals( true, sink.decode_frame(frame2.data(), frame2.size()) );
-	assertEquals( true, sink.is_done(FountainMetadata(1, 1600).id()) );
+	assertEquals( true, sink.is_done(FountainMetadata(1, 1600, 0).id()) );
 
 	assertEquals( 0, sink.num_streams() );
 	assertEquals( 2, sink.num_done() );

--- a/test/py/test_cimbar_cli.py
+++ b/test/py/test_cimbar_cli.py
@@ -38,7 +38,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
         self.assertTrue(getsize(encoded_img) > 30000)
 
         # decode
-        cmd = _get_command('-i', encoded_img, '-o', self.working_dir.name)
+        cmd = _get_command('-i', encoded_img, '-o', self.working_dir.name, '--no-deskew')
         res = subprocess.run(cmd, stdout=PIPE)
         self.assertEqual(0, res.returncode)
 
@@ -69,7 +69,7 @@ class CimbarCliTest(TestDirMixin, TestCase):
         self.assertTrue(getsize(encoded_img) > 30000)
 
         # decode defaults to cwd -- which should be self.working_dir
-        cmd = _get_command()
+        cmd = _get_command('--no-deskew')
         res = subprocess.run(
             cmd, input=encoded_img.encode('utf-8'), stdout=PIPE,
             cwd=self.working_dir.name,
@@ -86,4 +86,3 @@ class CimbarCliTest(TestDirMixin, TestCase):
             actual = r.read()
 
         self.assertEqual(expected, actual)
-

--- a/web/main.js
+++ b/web/main.js
@@ -156,7 +156,7 @@ return {
 
   setColorBits : function(color_bits)
   {
-    Module._configure(color_bits, 255, 255);
+    Module._configure(color_bits, 255, 255, true);
 
     var nav = document.getElementById("nav-container");
     if (color_bits == 2) {


### PR DESCRIPTION
This operates as a distinct option from the other config parameters (grid size, tile size, number of colors, ...), and like number of colors is a runtime parameter.

The motivation is to allow the symbol decode to occur independently of the color decode, allowing
(1) the decode to succeed -- at reduced capacity -- even if the color decode fails,
(2) the color decode to use the information it has from the symbol decode to generate a better color correction matrix, which will allow the color decode to succeed in a larger variety of conditions.

As an added bonus, the *color* decode can succeed while the symbol decode fails -- but in practice should not be common (in any case, it's not ideal).

The end result here is a new version of libcimbar, `0.6.0`, and a change to the format which will be called "mode B". The `0.5.x` versions ("4-color" and "8-color") will be "mode 4C" and "mode 8C" respectively. "mode 8C" support will be removed in `0.6.0`, but 4C (the more useful one) will continue to be supported until at *least* `0.7.0`, whenever that happens.

