### PR TITLE
Switch encoder default back to 4C for now

### DIFF
--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
 		("c,colorbits", "Color bits. [0-3]", cxxopts::value<int>()->default_value(turbo::str::str(colorBits)))
 		("e,ecc", "ECC level", cxxopts::value<unsigned>()->default_value(turbo::str::str(ecc)))
 		("f,fps", "Target FPS", cxxopts::value<unsigned>()->default_value(turbo::str::str(defaultFps)))
-		("m,mode", "Select a cimbar mode. B (the default) is new to 0.6.x. 4C is the 0.5.x config. [B,4C]", cxxopts::value<string>()->default_value("B"))
+		("m,mode", "Select a cimbar mode. B is new to 0.6.x. 4C is the 0.5.x config. [B,4C]", cxxopts::value<string>()->default_value("4C"))
 		("z,compression", "Compression level. 0 == no compression.", cxxopts::value<int>()->default_value(turbo::str::str(compressionLevel)))
 		("h,help", "Print usage")
 	;

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -22,7 +22,7 @@ namespace {
 	unsigned _ecc = cimbar::Config::ecc_bytes();
 	unsigned _colorBits = cimbar::Config::color_bits();
 	int _compressionLevel = cimbar::Config::compression_level();
-	bool _legacyMode = false;
+	bool _legacyMode = true;
 }
 
 extern "C" {

--- a/web/index.html
+++ b/web/index.html
@@ -271,7 +271,7 @@ body {
 
 <input style="display:none;" type="file" name="file_input" id="file_input" onchange="Main.fileInput(this);" />
 
-<div id="nav-container" class="mode-b">
+<div id="nav-container" class="mode-4c">
     <div class="bg" onclick="Main.blurNav();"></div>
     <button id="nav-button" tabindex="0" onclick="Main.clickNav();">
       <span class="icon-bar"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -286,7 +286,7 @@ body {
         <li><a href="javascript:void(0)" onclick="Main.toggleFullscreen()">Fullscreen</a></li>
         <hr>
         <li><a class="mode-b" href="javascript:void(0)" onclick="Main.setMode('B')">Mode B</a></li>
-        <li><a class="mode-4c" href="javascript:void(0)" onclick="Main.setMode('4C')">Mode 4C</a></li>
+        <li><a class="mode-4c" href="javascript:void(0)" onclick="Main.setMode('4C')">4C <small>(old apps)</small></a></li>
         <li class="small"><a href="https://github.com/sz3/libcimbar">github</a></li>
         <li class="small"><a href="https://github.com/sz3/cfc/releases/latest">android app</a></li>
       </ul>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 
-var _cacheName = 'cimbar-js-v0.5.14';
+var _cacheName = 'cimbar-js-v0.6.0';
 var _cacheFiles = [
   '/',
   '/index.html',


### PR DESCRIPTION
Follow up to #91 and #92, which introduce a new cimbar configuration ("mode B") and make it the default.

While it *will* become the default, the migration to the new mode should be easier if we do it in steps. Old apps are still expecting the old mode, after all. So, for 0.6.0 we'll keep the old 4-color config ("mode 4C") as the default for cimbar_js and cimbar_send (the encoder pieces).