### PR TITLE
Update decoder objects for per-frame mode switching

### DIFF
--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv)
 		string mode = result["mode"].as<string>();
 		legacy_mode = (mode == "4c") or (mode == "4C");
 	}
+	unsigned color_mode = legacy_mode? 0 : 1;
 
 	unsigned fps = result["fps"].as<unsigned>();
 	if (fps == 0)
@@ -104,8 +105,7 @@ int main(int argc, char** argv)
 	window.auto_scale_to_window();
 
 	Extractor ext;
-	unsigned color_mode = legacy_mode? 0 : 1;
-	Decoder dec(-1, -1, color_mode, legacy_mode);
+	Decoder dec(-1, -1);
 
 	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits(), legacy_mode);
 	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> sink(outpath, chunkSize);
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
 			shouldPreprocess = true;
 
 		// decode
-		int bytes = dec.decode_fountain(img, sink, shouldPreprocess);
+		int bytes = dec.decode_fountain(img, sink, color_mode, shouldPreprocess);
 		if (bytes > 0)
 			std::cerr << "got some bytes " << bytes << std::endl;
 	}

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -54,11 +54,10 @@ namespace {
 	}
 }
 
-CimbDecoder::CimbDecoder(unsigned symbol_bits, unsigned color_bits, unsigned color_mode, bool dark, uchar ahashThreshold)
+CimbDecoder::CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark, uchar ahashThreshold)
 	: _symbolBits(symbol_bits)
 	, _numSymbols(1 << symbol_bits)
 	, _numColors(1 << color_bits)
-	, _colorMode(color_mode)
 	, _dark(dark)
 	, _ahashThreshold(ahashThreshold)
 {
@@ -160,12 +159,12 @@ unsigned CimbDecoder::check_color_distance(std::tuple<uchar,uchar,uchar> a, std:
 	return color_diff(a, b);
 }
 
-std::tuple<uchar,uchar,uchar> CimbDecoder::get_color(int i) const
+std::tuple<uchar,uchar,uchar> CimbDecoder::get_color(int i, unsigned color_mode) const
 {
-	return cimbar::getColor(i, _numColors, _colorMode);
+	return cimbar::getColor(i, _numColors, color_mode);
 }
 
-unsigned CimbDecoder::get_best_color(float r, float g, float b) const
+unsigned CimbDecoder::get_best_color(float r, float g, float b, unsigned color_mode) const
 {
 	// transform color with ccm
 	if (internal_ccm().active())
@@ -188,7 +187,7 @@ unsigned CimbDecoder::get_best_color(float r, float g, float b) const
 	float best_distance = 1000000;
 	for (unsigned i = 0; i < _numColors; ++i)
 	{
-		std::tuple<uchar,uchar,uchar> candidate = get_color(i);
+		std::tuple<uchar,uchar,uchar> candidate = get_color(i, color_mode);
 		unsigned distance = check_color_distance(c, candidate);
 		if (distance < best_distance)
 		{
@@ -208,12 +207,12 @@ std::tuple<uchar,uchar,uchar> CimbDecoder::avg_color(const Cell& color_cell) con
 	return center.mean_rgb();
 }
 
-unsigned CimbDecoder::decode_color(const Cell& color_cell) const
+unsigned CimbDecoder::decode_color(const Cell& color_cell, unsigned color_mode) const
 {
 	if (_numColors <= 1)
 		return 0;
 	auto [r, g, b] = avg_color(color_cell);
-	return get_best_color(r, g, b);
+	return get_best_color(r, g, b, color_mode);
 }
 
 bool CimbDecoder::expects_binary_threshold() const

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -13,7 +13,7 @@
 class CimbDecoder
 {
 public:
-	CimbDecoder(unsigned symbol_bits, unsigned color_bits, unsigned color_mode=1, bool dark=true, uchar ahashThreshold=0);
+	CimbDecoder(unsigned symbol_bits, unsigned color_bits, bool dark=true, uchar ahashThreshold=0);
 
 	const color_correction& get_ccm() const;
 	void update_color_correction(cv::Matx<float, 3, 3>&& ccm);
@@ -22,10 +22,10 @@ public:
 	unsigned decode_symbol(const cv::Mat& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 
-	std::tuple<uchar,uchar,uchar> get_color(int i) const;
+	std::tuple<uchar,uchar,uchar> get_color(int i, unsigned color_mode) const;
 	std::tuple<uchar,uchar,uchar> avg_color(const Cell& color_cell) const;
-	unsigned get_best_color(float r, float g, float b) const;
-	unsigned decode_color(const Cell& cell) const;
+	unsigned get_best_color(float r, float g, float b, unsigned color_mode) const;
+	unsigned decode_color(const Cell& cell, unsigned color_mode) const;
 
 	bool expects_binary_threshold() const;
 	unsigned symbol_bits() const;
@@ -44,7 +44,6 @@ protected:
 	unsigned _symbolBits;
 	unsigned _numSymbols;
 	unsigned _numColors;
-	unsigned _colorMode;
 	bool _dark;
 	uchar _ahashThreshold;
 };

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -90,7 +90,7 @@ namespace {
 	}
 }
 
-CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen, int color_correction)
+CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen, int color_correction)
 	: _image(img)
 	, _fountainColorHeader(0U)
 	, _cellSize(Config::cell_size() + 2)
@@ -98,21 +98,22 @@ CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_shar
 	, _decoder(decoder)
 	, _good(_image.cols >= Config::image_size() and _image.rows >= Config::image_size())
 	, _colorCorrection(color_correction)
+	, _colorMode(color_mode)
 {
 	_grayscale = preprocessSymbolGrid(img, needs_sharpen);
 	if (_good and color_correction == 1)
 		simpleColorCorrection(_image, decoder);
 }
 
-CimbReader::CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen, int color_correction)
-	: CimbReader(img.getMat(cv::ACCESS_READ), decoder, needs_sharpen, color_correction)
+CimbReader::CimbReader(const cv::UMat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen, int color_correction)
+	: CimbReader(img.getMat(cv::ACCESS_READ), decoder, color_mode, needs_sharpen, color_correction)
 {
 }
 
 unsigned CimbReader::read_color(const PositionData& pos) const
 {
 	Cell color_cell(_image, pos.x, pos.y, Config::cell_size(), Config::cell_size());
-	return _decoder.decode_color(color_cell);
+	return _decoder.decode_color(color_cell, _colorMode);
 }
 
 unsigned CimbReader::read(PositionData& pos)
@@ -219,7 +220,7 @@ void CimbReader::init_ccm(unsigned color_bits, unsigned interleave_blocks, unsig
 		cv::Mat arow = (cv::Mat_<float>(1,3) << std::get<1>(it.second), std::get<2>(it.second), std::get<3>(it.second));
 		actual.push_back(arow);
 
-		cimbar::RGB cc = _decoder.get_color(it.first);
+		cimbar::RGB cc = _decoder.get_color(it.first, _colorMode);
 		cv::Mat drow = (cv::Mat_<float>(1,3) << std::get<0>(cc), std::get<1>(cc), std::get<2>(cc));
 		desired.push_back(drow);
 	}

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -12,8 +12,8 @@
 class CimbReader
 {
 public:
-	CimbReader(const cv::Mat& img, CimbDecoder& decoder, bool needs_sharpen=false, int color_correction=2);
-	CimbReader(const cv::UMat& img, CimbDecoder& decoder, bool needs_sharpen=false, int color_correction=2);
+	CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen=false, int color_correction=2);
+	CimbReader(const cv::UMat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen=false, int color_correction=2);
 
 	unsigned read(PositionData& pos);
 	unsigned read_color(const PositionData& pos) const;
@@ -34,4 +34,5 @@ protected:
 	CimbDecoder& _decoder;
 	bool _good;
 	int _colorCorrection;
+	unsigned _colorMode;
 };

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -80,7 +80,6 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream, bool leg
 	colorPositions.resize(reader.num_reads()); // the number of cells == reader.num_reads(). Can we calculate this from config at compile time? Do we care?
 
 	unsigned bitsPerSymbol = cimbar::Config::symbol_bits();
-	unsigned bytesDecoded = 0;
 	{
 		bitbuffer symbolBits(cimbar::Config::capacity(bitsPerSymbol));
 		// read symbols first
@@ -116,8 +115,8 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream, bool leg
 	}
 
 	reed_solomon_stream rss(ostream, _eccBytes, _eccBlockSize);
-	bytesDecoded += colorBits.flush(rss);  // will return the pos after this flush(), which includes the previous flush()...
-	return bytesDecoded;
+	// flush() will return the (good) cumulative bytes written to the underlying stream
+	return colorBits.flush(rss);
 }
 
 template <typename STREAM>

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -8,6 +8,7 @@
 #include "cimb_translator/Config.h"
 #include "cimb_translator/Interleave.h"
 #include "util/File.h"
+#include "util/null_stream.h"
 
 #include <opencv2/opencv.hpp>
 #include <functional>
@@ -166,8 +167,22 @@ template <typename MAT, typename FOUNTAINSTREAM>
 inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream,  unsigned color_mode, bool should_preprocess, int color_correction)
 {
 	CimbReader reader(img, _decoder, color_mode, should_preprocess, color_correction);
-	aligned_stream aligner(ostream, ostream.chunk_size(), 0, std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2));
-	return do_decode(reader, aligner, color_mode==0);
+	bool legacy_mode = color_mode == 0;
+	unsigned chunk_size = cimbar::Config::fountain_chunk_size(_eccBytes, _bitsPerOp, legacy_mode);
+	auto update_md_fun = std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2);
+
+	// we don't want to feed the fountain stream bad data, so we eat the decode if we have a mismatch
+	// we still might succeed the decode, in which case (hopefully) the positive bytes we return will
+	// tell our caller to fix the underlying ostream so the next round will work.
+	if (ostream.chunk_size() != chunk_size)
+	{
+		null_stream devnull;
+		aligned_stream aligner(devnull, chunk_size, 0, update_md_fun);
+		return do_decode(reader, aligner, legacy_mode);
+	}
+
+	aligned_stream aligner(ostream, ostream.chunk_size(), 0, update_md_fun);
+	return do_decode(reader, aligner, legacy_mode);
 }
 
 inline unsigned Decoder::decode(std::string filename, std::string output, unsigned color_mode)

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -16,22 +16,22 @@
 class Decoder
 {
 public:
-	Decoder(int ecc_bytes=-1, int color_bits=-1, unsigned color_mode=1, bool coupled=false, bool interleave=true);
+	Decoder(int ecc_bytes=-1, int color_bits=-1, bool interleave=true);
 
 	template <typename MAT, typename STREAM>
-	unsigned decode(const MAT& img, STREAM& ostream, bool should_preprocess=false, int color_correction=2);
+	unsigned decode(const MAT& img, STREAM& ostream, unsigned color_mode=1, bool should_preprocess=false, int color_correction=2);
 
 	template <typename MAT, typename STREAM>
-	unsigned decode_fountain(const MAT& img, STREAM& ostream, bool should_preprocess=false, int color_correction=2);
+	unsigned decode_fountain(const MAT& img, STREAM& ostream, unsigned color_mode=1, bool should_preprocess=false, int color_correction=2);
 
-	unsigned decode(std::string filename, std::string output);
+	unsigned decode(std::string filename, std::string output, unsigned color_mode=1);
 
 	bool load_ccm(std::string filename);
 	bool save_ccm(std::string filename);
 
 protected:
 	template <typename STREAM>
-	unsigned do_decode(CimbReader& reader, STREAM& ostream);
+	unsigned do_decode(CimbReader& reader, STREAM& ostream, bool legacy_mode);
 
 	template <typename STREAM>
 	unsigned do_decode_coupled(CimbReader& reader, STREAM& ostream);
@@ -41,23 +41,19 @@ protected:
 	unsigned _eccBlockSize;
 	unsigned _colorBits;
 	unsigned _bitsPerOp;
-	bool _coupled;
-	unsigned _colorMode;
 	unsigned _interleaveBlocks;
 	unsigned _interleavePartitions;
 	CimbDecoder _decoder;
 };
 
-inline Decoder::Decoder(int ecc_bytes, int color_bits, unsigned color_mode, bool coupled, bool interleave)
+inline Decoder::Decoder(int ecc_bytes, int color_bits, bool interleave)
 	: _eccBytes(ecc_bytes >= 0? ecc_bytes : cimbar::Config::ecc_bytes())
 	, _eccBlockSize(cimbar::Config::ecc_block_size())
 	, _colorBits(color_bits >= 0? color_bits : cimbar::Config::color_bits())
 	, _bitsPerOp(cimbar::Config::symbol_bits() + _colorBits)
-	, _coupled(coupled)
-	, _colorMode(color_mode)
 	, _interleaveBlocks(interleave? cimbar::Config::interleave_blocks() : 0)
 	, _interleavePartitions(cimbar::Config::interleave_partitions())
-	, _decoder(cimbar::Config::symbol_bits(), _colorBits, color_mode, cimbar::Config::dark(), 0xFF)
+	, _decoder(cimbar::Config::symbol_bits(), _colorBits, cimbar::Config::dark(), 0xFF)
 {
 }
 
@@ -74,9 +70,9 @@ inline Decoder::Decoder(int ecc_bytes, int color_bits, unsigned color_mode, bool
  *
  * */
 template <typename STREAM>
-inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
+inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream, bool legacy_mode)
 {
-	if (_coupled)
+	if (legacy_mode)
 		return do_decode_coupled(reader, ostream);
 
 	std::vector<unsigned> interleaveLookup = Interleave::interleave_reverse(reader.num_reads(), _interleaveBlocks, _interleavePartitions);
@@ -109,7 +105,7 @@ inline unsigned Decoder::do_decode(CimbReader& reader, STREAM& ostream)
 	}
 
 	// do color correction init, now that we (hopefully) have some fountain headers from the symbol decode
-	reader.init_ccm(_colorBits, _interleaveBlocks, _interleavePartitions, cimbar::Config::fountain_chunks_per_frame(_bitsPerOp, _coupled and _colorMode==0));
+	reader.init_ccm(_colorBits, _interleaveBlocks, _interleavePartitions, cimbar::Config::fountain_chunks_per_frame(_bitsPerOp, legacy_mode));
 
 	bitbuffer colorBits(cimbar::Config::capacity(_colorBits));
 	// then decode colors.
@@ -161,27 +157,27 @@ inline unsigned Decoder::do_decode_coupled(CimbReader& reader, STREAM& ostream)
 }
 
 template <typename MAT, typename STREAM>
-inline unsigned Decoder::decode(const MAT& img, STREAM& ostream, bool should_preprocess, int color_correction)
+inline unsigned Decoder::decode(const MAT& img, STREAM& ostream, unsigned color_mode, bool should_preprocess, int color_correction)
 {
-	CimbReader reader(img, _decoder, should_preprocess, color_correction);
-	return do_decode(reader, ostream);
+	CimbReader reader(img, _decoder, color_mode, should_preprocess, color_correction);
+	return do_decode(reader, ostream, color_mode==0);
 }
 
 template <typename MAT, typename FOUNTAINSTREAM>
-inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream, bool should_preprocess, int color_correction)
+inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream,  unsigned color_mode, bool should_preprocess, int color_correction)
 {
-	CimbReader reader(img, _decoder, should_preprocess, color_correction);
+	CimbReader reader(img, _decoder, color_mode, should_preprocess, color_correction);
 	aligned_stream aligner(ostream, ostream.chunk_size(), 0, std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2));
-	return do_decode(reader, aligner);
+	return do_decode(reader, aligner, color_mode==0);
 }
 
-inline unsigned Decoder::decode(std::string filename, std::string output)
+inline unsigned Decoder::decode(std::string filename, std::string output, unsigned color_mode)
 {
 	cv::Mat img = cv::imread(filename);
 	cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 
 	std::ofstream f(output);
-	return decode(img, f, false);
+	return decode(img, f, color_mode, false);
 }
 
 inline bool Decoder::load_ccm(std::string filename)

--- a/src/lib/encoder/reed_solomon_stream.h
+++ b/src/lib/encoder/reed_solomon_stream.h
@@ -88,7 +88,7 @@ protected:
 	bool _good;
 };
 
-inline std::ifstream& operator<<(std::ifstream& s, const ReedSolomon::BadChunk& chunk)
+inline std::ifstream& operator<<(std::ifstream& s, const ReedSolomon::BadChunk&)
 {
 	return s;
 }

--- a/src/lib/encoder/test/DecoderTest.cpp
+++ b/src/lib/encoder/test/DecoderTest.cpp
@@ -65,9 +65,9 @@ TEST_CASE( "DecoderTest/testDecode.4c", "[unit]" )
 	// legacy format
 	MakeTempDirectory tempdir;
 
-	Decoder dec(0, 2, 0, true);
+	Decoder dec(0, 2, true);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
-	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile, 0);
 	assertEquals( 9300, bytesDecoded );
 
 	assertEquals( "7e1919b1210ccc332fc56e8b35cccd622d980f03c6c3b32338bb00aa4b6a22a2", get_hash(decodedFile) );
@@ -77,9 +77,9 @@ TEST_CASE( "DecoderTest/testDecodeEcc.4c", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
-	Decoder dec(30, 2, 0, true);
+	Decoder dec(30, 2, true);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
-	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile);
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4color_ecc30_fountain_0.png"), decodedFile, 0);
 	assertEquals( 7500, bytesDecoded );
 
 	assertEquals( "382c76644a4dff475c5793c5fe061e35e47be252010d29aeaf8d93ee6a3f7045", get_hash(decodedFile) );
@@ -90,9 +90,9 @@ TEST_CASE( "DecoderTest/testDecode.Sample4c", "[unit]" )
 	// regression test -- useful for now, but is very brittle
 	MakeTempDirectory tempdir;
 
-	Decoder dec(0, 2, 0, true);
+	Decoder dec(0, 2, true);
 	std::string decodedFile = tempdir.path() / "testDecode.txt";
-	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4_30_f0_627_extract.jpg"), decodedFile);
+	unsigned bytesDecoded = dec.decode(TestCimbar::getSample("6bit/4_30_f0_627_extract.jpg"), decodedFile, 0);
 	assertEquals( 9300, bytesDecoded );
 
 	if (CV_VERSION_MAJOR == 4)

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -64,9 +64,10 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 
 	// will be padded so the fountain encoding is happy. The encoded image looks suspiciously non-random!
 	Encoder enc(30, 4, 2);
+	enc.set_legacy_mode();
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xeecc8800efce8c48;
+	uint64_t hash = 0xaecc8c00efce8c28;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat encodedImg = cv::imread(path);
 	cv::cvtColor(encodedImg, encodedImg, cv::COLOR_BGR2RGB);
@@ -75,10 +76,11 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	// decoder
 	Decoder dec(30);
 	// sink with a mismatched fountain_chunk_size
-	// importantly, the sink expects a *larger* chunk than we'll give it...
-	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6, true));
+	// importantly, the sink expects a *smaller* chunk than we'll give it...
+	// because that's a more interesting test...
+	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6, false));
 
-	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds, 1);
+	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds, 0);
 	assertEquals( 7500, bytesDecoded );
 
 	assertEquals( 0, fds.num_done() );

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	Decoder dec(30);
 	fountain_decoder_sink<cimbar::zstd_decompressor<std::ofstream>> fds(tempdir.path(), cimbar::Config::fountain_chunk_size(30, 6, false));
 
-	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
+	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds, 1);
 	assertEquals( 7500, bytesDecoded );
 
 	std::string decodedContents = File(tempdir.path() / "0.626").read_all();
@@ -71,7 +71,7 @@ TEST_CASE( "EncoderRoundTripTest/testStreaming", "[unit]" )
 		std::optional<cv::Mat> frame = enc.encode_next(*fes);
 		assertTrue( frame );
 
-		unsigned bytesDecoded = dec.decode_fountain(*frame, fds);
+		unsigned bytesDecoded = dec.decode_fountain(*frame, fds, 1);
 		assertEquals( 7500, bytesDecoded );
 
 		if (fds.num_done())

--- a/src/lib/util/null_stream.h
+++ b/src/lib/util/null_stream.h
@@ -1,0 +1,28 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+class null_stream
+{
+public:
+	null_stream()
+	{}
+
+	null_stream& write(const char*, unsigned length)
+	{
+		_count += length;
+		return *this;
+	}
+
+	bool good() const
+	{
+		return true;
+	}
+
+	long tellp() const
+	{
+		return _count;
+	}
+
+protected:
+	long _count = 0;
+};


### PR DESCRIPTION
Motivation: per-frame bouncing between color_mode, so we can test success/failure for mode B/4C and pick the one that's working.

Details:
When running a decoder across multiple frames, we have certain state (loaded hashes for imagehash hamming distance, for example) that is longer lived -- that we don't want to run each frame. This *currently* is stored in the CimbDecoder (also the fountain_decoder_sink, though that's not relevant to this change). To allow us to switch between modes, we need the CimbDecoder to not store color_mode, but rather take it as an argument where required.

Misc:
There are other ways to accomplish this, but this change seems like the best immediate path forward. The actual technical requirement is:
(1) to run in different modes
(2) on different threads
(3) at the same time.