### PR TITLE
Misc tweaks/updates to cimbar.js encoder UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,8 +21,8 @@ html, body {
 body {
 	background-color: white;
 	background-image: linear-gradient(135deg, rgb(0,0,0) 65px, transparent 130px),
-repeating-linear-gradient(135deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px, transparent 30px),
-repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px, transparent 30px);
+repeating-linear-gradient(135deg, rgb(0,0,0) 0px, rgb(153,197,206) 1px,transparent 1px, transparent 30px),
+repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(153,197,206) 1px,transparent 1px, transparent 30px);
 	background-size: cover;
 	color: gray;
 	display: grid;
@@ -38,10 +38,6 @@ repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px,
 
 #invisible_click, #canvas, #nav-container {
 	z-index: 1;
-}
-
-#nav-button {
-	z-index: 2;
 }
 
 #canvas {
@@ -277,6 +273,8 @@ repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px,
 
 <input style="display:none;" type="file" name="file_input" id="file_input" onchange="Main.fileInput(this);" />
 
+<a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
+
 <div id="nav-container" class="mode-4c">
     <div class="bg" onclick="Main.blurNav();"></div>
     <button id="nav-button" tabindex="0" onclick="Main.clickNav();">
@@ -298,7 +296,6 @@ repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px,
       </ul>
     </div>
 </div>
-<a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
 
 <script type="text/javascript">
 	if ('serviceWorker' in navigator) {

--- a/web/index.html
+++ b/web/index.html
@@ -20,7 +20,9 @@ html, body {
 
 body {
 	background-color: white;
-	background-image: radial-gradient(circle at top left, rgb(7,0,0),transparent,transparent), repeating-linear-gradient(0deg, rgb(153,197,206) 0px, rgb(153,197,206) 1px, transparent 1px, transparent 30px), repeating-linear-gradient(0deg, rgb(153,197,206) 0px, rgb(153,197,206) 2px, transparent 2px, transparent 150px), repeating-linear-gradient(90deg, rgb(153,197,206) 0px, rgb(153,197,206) 1px, transparent 1px, transparent 30px),repeating-linear-gradient(90deg, rgb(153,197,206) 0px, rgb(153,197,206) 2px, transparent 2px, transparent 150px), linear-gradient(white, white);
+	background-image: linear-gradient(135deg, rgb(0,0,0) 65px, transparent 130px),
+repeating-linear-gradient(135deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px, transparent 30px),
+repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(0,0,0) 1px,transparent 1px, transparent 30px);
 	background-size: cover;
 	color: gray;
 	display: grid;

--- a/web/index.html
+++ b/web/index.html
@@ -36,9 +36,13 @@ repeating-linear-gradient(45deg, rgb(0,0,0) 0px, rgb(153,197,206) 1px,transparen
 	top: 0;
 }
 
-#invisible_click, #canvas, #nav-container {
+#nav-container:focus-within {
 	z-index: 1;
 }
+
+#nav-content, #nav-container .bg,  #nav-container:focus-within #nav-button {
+ 	z-index: 1;
+ }
 
 #canvas {
 	display: block;

--- a/web/index.html
+++ b/web/index.html
@@ -56,7 +56,7 @@ body {
 	box-shadow: 0px 0px 12px black, 0px 0px 18px black;
 }
 
-#dragdrop::before {
+.dragdrop::before {
 	content: "⌜ Tap to start! ⌟";
 	font: 1.5em serif;
 	padding-top: 2em;
@@ -64,6 +64,10 @@ body {
 	left: 0;
 	text-align: center;
 	width: 100%;
+}
+
+.dragdrop.error:before {
+	content: "⌜ Error! WebGL is not enabled :( ⌟";
 }
 
 #invisible_click {
@@ -303,7 +307,7 @@ body {
 	var Module = {};
 	Module.canvas = canvas;
 	Module.onRuntimeInitialized = () => {
-		Main.init();
+		Main.init(canvas);
 		Main.nextFrame();
 	};
 </script>

--- a/web/main.js
+++ b/web/main.js
@@ -1,6 +1,7 @@
 var Main = function() {
 
 var _interval = 66;
+var _pause = false;
 
 var _showStats = false;
 var _renders = 0;
@@ -69,6 +70,16 @@ return {
     toggleFullscreen().then(Main.resize);
   },
 
+  togglePause : function(pause)
+  {
+    if (pause === undefined) {
+       _pause = !_pause;
+    }
+    else {
+       _pause = pause;
+    }
+  },
+
   scaleCanvas : function(canvas, width, height)
   {
     var dim = width;
@@ -123,6 +134,7 @@ return {
     document.getElementById("nav-button").blur();
     document.getElementById("nav-content").blur();
     document.getElementById("nav-find-file-link").blur();
+    Main.togglePause(false);
   },
 
   clickFileInput : function()
@@ -142,7 +154,9 @@ return {
   nextFrame : function()
   {
     var start = performance.now();
-    Module._render();
+    if (!_pause) {
+       Module._render();
+    }
     var frameCount = Module._next_frame();
 
     var elapsed = performance.now() - start;
@@ -201,6 +215,10 @@ window.addEventListener('keydown', function(e) {
         e.key == 'Space' || e.keyCode == 32
     ) {
       Main.clickNav();
+      e.preventDefault();
+    }
+    else if (e.key == 'Backspace' || e.keyCode == 8) {
+      Main.togglePause();
       e.preventDefault();
     }
   }
@@ -267,6 +285,21 @@ window.addEventListener('keydown', function(e) {
     }
   }
 }, true);
+
+window.addEventListener("touchstart", function(e) {
+  e = e || event;
+  Main.togglePause(true);
+}, false);
+
+window.addEventListener("touchend", function(e) {
+  e = e || event;
+  Main.togglePause(false);
+}, false);
+
+window.addEventListener("touchcancel", function(e) {
+  e = e || event;
+  Main.togglePause(false);
+}, false);
 
 window.addEventListener("dragover", function(e) {
   e = e || event;

--- a/web/main.js
+++ b/web/main.js
@@ -4,7 +4,7 @@ var _interval = 66;
 var _pause = false;
 
 var _showStats = false;
-var _renders = 0;
+var _counter = 0;
 var _renderTime = 0;
 
 function toggleFullscreen()
@@ -68,6 +68,7 @@ return {
   toggleFullscreen : function()
   {
     toggleFullscreen().then(Main.resize);
+    Main.togglePause(false);
   },
 
   togglePause : function(pause)
@@ -96,6 +97,7 @@ return {
 
   alignInvisibleClick : function(canvas)
   {
+     canvas = canvas || document.getElementById('canvas');
      var cpos = canvas.getBoundingClientRect();
      var invisible_click = document.getElementById("invisible_click");
      invisible_click.style.width = canvas.style.width;
@@ -127,6 +129,7 @@ return {
   clickNav : function()
   {
     document.getElementById("nav-button").focus();
+    Main.togglePause(false);
   },
 
   blurNav : function()
@@ -140,6 +143,7 @@ return {
   clickFileInput : function()
   {
     document.getElementById("file_input").click();
+    Main.togglePause(false);
   },
 
   fileInput : function(ev)
@@ -153,11 +157,12 @@ return {
 
   nextFrame : function()
   {
+    _counter += 1;
     var start = performance.now();
     if (!_pause) {
        Module._render();
+       var frameCount = Module._next_frame();
     }
-    var frameCount = Module._next_frame();
 
     var elapsed = performance.now() - start;
     var nextInterval = _interval>elapsed? _interval-elapsed : 0;
@@ -166,6 +171,9 @@ return {
     if (_showStats && frameCount) {
       _renderTime += elapsed;
       Main.setHTML( "status", elapsed + " : " + frameCount + " : " + Math.ceil(_renderTime/frameCount));
+    }
+    if (_counter & 16 > 0) {
+       Main.alignInvisibleClick();
     }
   },
 
@@ -193,6 +201,7 @@ return {
       nav.classList.remove("mode-b");
       nav.classList.remove("mode-4c");
     }
+    Main.togglePause(false);
   },
 
   setHTML : function(id, msg)

--- a/web/main.js
+++ b/web/main.js
@@ -75,11 +75,9 @@ return {
   {
     // pause is a cooldown. We pause to help autofocus, but we don't want to do it forever...
     if (pause === undefined) {
-       _pause = Main.isPaused()? 0 : 32;
+       pause = !Main.isPaused();
     }
-    else {
-       _pause = pause? 32 : 0;
-    }
+    _pause = pause? 15 : 0;
   },
 
   isPaused : function()
@@ -236,7 +234,7 @@ window.addEventListener('keydown', function(e) {
       e.preventDefault();
     }
     else if (e.key == 'Backspace' || e.keyCode == 8) {
-      Main.togglePause();
+      Main.togglePause(true);
       e.preventDefault();
     }
   }

--- a/web/main.js
+++ b/web/main.js
@@ -59,8 +59,8 @@ return {
   {
     // reset zoom
     var canvas = document.getElementById('canvas');
-    var width = window.innerWidth;
-    var height = window.outerHeight;
+    var width = window.innerWidth - 12;
+    var height = window.outerHeight - 12;
     Main.scaleCanvas(canvas, width, height);
     Main.alignInvisibleClick(canvas);
   },
@@ -91,10 +91,7 @@ return {
     if (height < dim) {
       dim = height;
     }
-    console.log(dim);
-    if (dim > 1040) {
-      dim = 1040;
-    }
+    console.log(dim + "x" + dim);
     canvas.style.width = dim + "px";
     canvas.style.height = dim + "px";
   },

--- a/web/main.js
+++ b/web/main.js
@@ -43,6 +43,15 @@ return {
   {
     Module._initialize_GL(1040, 1040);
     Main.resize();
+    Main.check_GL_enabled(canvas);
+  },
+
+  check_GL_enabled : function(canvas)
+  {
+    if (canvas.getContext("2d")) {
+       var elem = document.getElementById('dragdrop');
+       elem.classList.add("error");
+    }
   },
 
   resize : function()


### PR DESCRIPTION
A bunch of small stuff:
* error message is now displayed when webGL fails init (https://github.com/sz3/libcimbar/issues/95)
* toggling the menu now temporarily pauses barcode animation for 15 frames (1 second)
    * of all the tricks I tried to get auto-focus to work better, pausing the animation is far and away the best
* on mobile, the touch event (press the screen anywhere) will also pause the feed
* new background. Very exciting and cool.
* auto-expand canvas to fill window on larger displays (was previously capped to the cimbar res of 1024x1024 +padding).
    * long overdue, probably
* make sure there's always minimum padding around the barcode