### PR TITLE
Upgrade opencv + docker image used for cimbar.js wasm build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ jobs:
 
       - name: Get openCV
         run: |
-          wget https://github.com/opencv/opencv/archive/refs/tags/4.5.5.zip
-          unzip 4.5.5.zip
-          mv opencv-4.5.5 opencv4
+          wget https://github.com/opencv/opencv/archive/refs/tags/4.10.0.zip
+          unzip 4.10.0.zip
+          mv opencv-4.10.0 opencv4
 
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: emscripten/emsdk:3.1.39
+          image: emscripten/emsdk:3.1.69
           options: -v ${{ github.workspace }}:/usr/src/app
           shell: bash
           run: |

--- a/package-wasm.sh
+++ b/package-wasm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#docker run --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:3.1.39
+#docker run --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:3.1.69 bash
 
 cd /usr/src/app
 

--- a/src/third_party_lib/wirehair/CMakeLists.txt
+++ b/src/third_party_lib/wirehair/CMakeLists.txt
@@ -54,7 +54,7 @@ set(GEN_TABLES
         gf256.h
         )
 
-if(NOT ANDROID)
+if(NOT ANDROID AND NOT USE_WASM)
     set(ARCH_NATIVE "-march=native")
 endif()
 


### PR DESCRIPTION
* opencv to 4.10
* pin newer emscripten docker image
* minor tweak to the custom wirehair cmakelists to make sure -march is left off of the wasm build
   * might end up turning it off entirely? :thinking: 