### PR TITLE
Have the (cli) encoder skip unextractable frames

### DIFF
--- a/package-wasm.sh
+++ b/package-wasm.sh
@@ -16,7 +16,7 @@ mkdir build-wasm
 cd build-wasm
 emcmake cmake .. -DUSE_WASM=1 -DOPENCV_DIR=/usr/src/app/opencv4
 make -j5 install
-(cd ../web/ && tar -czvf cimbar.wasm.tar.gz cimbar_js.* index.html main.js)
+(cd ../web/ && tar -czvf cimbar.wasm.tar.gz cimbar_js.js cimbar_js.wasm index.html main.js)
 
 cd /usr/src/app
 mkdir build-asmjs

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -104,6 +104,7 @@ template <typename FilenameIterable>
 int encode(const FilenameIterable& infiles, const std::string& outpath, int ecc, int color_bits, int compression_level, bool legacy_mode, bool no_fountain)
 {
 	Encoder en(ecc, cimbar::Config::symbol_bits(), color_bits);
+	en.set_encode_id(109);
 	if (legacy_mode)
 		en.set_legacy_mode();
 	for (const string& f : infiles)

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -68,12 +68,11 @@ int next_frame()
 	if (!_window or !_fes)
 		return 0;
 
-	// we generate 5x the amount of required symbol blocks -- unless everything fits in a single frame.
-	// color blocks will contribute to this total, but only symbols are used for the initial calculation.
-	// ... this way, if the color decode is failing, it won't get "stuck" failing to read a single frame.
-	unsigned required = _fes->blocks_required();
-	if (required > cimbar::Config::fountain_chunks_per_frame(cimbar::Config::symbol_bits(), _legacyMode))
-		required = required*5;
+	// we generate 8x the amount of required symbol blocks.
+	// this number is somewhat arbitrary, but needs to not be
+	// *too* low (1-2), or we risk long runs of blocks the decoder
+	// has already seen.
+	unsigned required = _fes->blocks_required() * 8;
 	if (_fes->block_count() > required)
 	{
 		_fes->restart();

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -3,6 +3,7 @@
 
 #include "SimpleEncoder.h"
 #include "cimb_translator/Config.h"
+#include "extractor/Scanner.h"
 #include "serialize/format.h"
 
 #include <opencv2/opencv.hpp>
@@ -60,6 +61,13 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 		auto frame = encode_next(*fes, canvas_size);
 		if (!frame)
 			break;
+
+		// some % of generated frames (for the current 8x8 impl)
+		// will produce random patterns that falsely match as
+		// corner "anchors" and fail to extract. So:
+		// if frame fails the scan, skip it.
+		if (!Scanner::will_it_scan(*frame))
+			continue;
 
 		if (!on_frame(*frame, i))
 			break;

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -56,6 +56,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 		requiredFrames = 1;
 
 	unsigned i = 0;
+	unsigned consecutiveScansFailed = 0;
 	while (i < requiredFrames)
 	{
 		auto frame = encode_next(*fes, canvas_size);
@@ -67,8 +68,15 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 		// corner "anchors" and fail to extract. So:
 		// if frame fails the scan, skip it.
 		if (!Scanner::will_it_scan(*frame))
-			continue;
+		{
+			if (++consecutiveScansFailed < 5)
+				continue;
 
+			// else, we gotta make forward progress. And it's probably a bug?
+			std::cerr << fmt::format("generated {} bad frames in a row. This really shouldn't happen, maybe report a bug. :(", consecutiveScansFailed) << std::endl;
+		}
+
+		consecutiveScansFailed = 0;
 		if (!on_frame(*frame, i))
 			break;
 		++i;

--- a/src/lib/encoder/test/CMakeLists.txt
+++ b/src/lib/encoder/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_test(encoder_test encoder_test)
 target_link_libraries(encoder_test
 
 	cimb_translator
+	extractor
 
 	correct_static
 	wirehair

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -31,7 +31,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xeecc8800efce8c48;
+	uint64_t hash = 0xefcc8800efce8c48;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat encodedImg = cv::imread(path);
 	cv::cvtColor(encodedImg, encodedImg, cv::COLOR_BGR2RGB);

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE( "EncoderTest/testFountain.4c", "[unit]" )
 	enc.set_legacy_mode();
 	assertEquals( 3, enc.encode_fountain(inputFile, outPrefix, 0) );
 
-	std::vector<uint64_t> hashes = {0xbb1cc62b662abfe5, 0xf586f6466a5b194, 0x8c2f0f40e6ecb08b};
+	std::vector<uint64_t> hashes = {0xbb1cc62b662abfe5, 0xf586f6466a5b194, 0x93a3830d042966e1};
 	for (unsigned i = 0; i < hashes.size(); ++i)
 	{
 		DYNAMIC_SECTION( "are we correct? : " << i )
@@ -93,7 +93,7 @@ TEST_CASE( "EncoderTest/testFountain.Compress", "[unit]" )
 	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xb36b65402eec434e;
+	uint64_t hash = 0xa66a666543280e8e;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
 	assertEquals( hash, image_hash::average_hash(img) );
@@ -131,12 +131,12 @@ TEST_CASE( "EncoderTest/testFountain.Size", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	Encoder enc(30, 4, 2);
-	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6, 1080) );
+	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6, 1024) );
 
-	uint64_t hash = 0xbdc232c714226fe6;
+	uint64_t hash = 0xa66a666543280e8e;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
-	assertEquals( 1080, img.rows );
-	assertEquals( 1080, img.cols );
+	assertEquals( 1024, img.rows );
+	assertEquals( 1024, img.cols );
 	assertEquals( hash, image_hash::average_hash(img) );
 }


### PR DESCRIPTION
In investigating what might be causing #108, I remembered an error case I'd run into in the past but had thought/assumed/hoped was very rare: generating an "unextractable" frame -- that is, one which `cimbar_extract` will fail to extract (notwithstanding a hypothetical perfect extraction algorithm). This happens due to the extraction algorithm getting confused by data part of the code and failing to find the corner markers.

Turns out it's rare, but not rare enough. In my testing, anywhere between 1-2% (!) of generated frames are bogus in this way. This is *ok* for purposes of the main use case -- there will be another unique frame every 66ms or so. But for offline cases where we generate an image (or series of images) and check it later, it's *not* ok.

QR codes address this issue by having different "masking patterns" that can be selected. We don't have that option, but we do have a way to fix it: check the generated image after we generate, and make sure it extracts. If it doesn't, we skip that frame and try again.

Currently this is only used in the `cimbar` cli, not in the web encoder. I'll need to look at the performance implications some more to see if having the web encoder make the same check is a good idea.