### PR TITLE
opencv 4.11 for cimbar.js build + misc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
 
       - name: Get openCV
         run: |
-          wget https://github.com/opencv/opencv/archive/refs/tags/4.10.0.zip
-          unzip 4.10.0.zip
-          mv opencv-4.10.0 opencv4
+          git clone --recurse-submodules --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git opencv4
 
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.cmake/
 CMakeFiles/
 Testing/
-build/
+build*/
 dist/
+opencv4/
 web/cimbar_js.js
 web/cimbar_js.wasm
 CMakeCache.txt

--- a/package-wasm.sh
+++ b/package-wasm.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #docker run --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:3.1.69 bash
 
-cd /usr/src/app
+CIMBAR_ROOT=${CIMBAR_ROOT:-/usr/src/app}
+cd $CIMBAR_ROOT
 
 apt update
 apt install python3 -y
@@ -9,21 +10,21 @@ apt install python3 -y
 cd opencv4/
 mkdir opencv-build-wasm
 cd opencv-build-wasm
-python3 ../platforms/js/build_js.py build_wasm --build_wasm --emscripten_dir=/emsdk/upstream/emscripten
+python3 ../platforms/js/build_js.py build_wasm --emscripten_dir=/emsdk/upstream/emscripten
 
-cd /usr/src/app
+cd $CIMBAR_ROOT
 mkdir build-wasm
 cd build-wasm
-emcmake cmake .. -DUSE_WASM=1 -DOPENCV_DIR=/usr/src/app/opencv4
+emcmake cmake .. -DUSE_WASM=1 -DOPENCV_DIR=$CIMBAR_ROOT/opencv4
 make -j5 install
 (cd ../web/ && tar -czvf cimbar.wasm.tar.gz cimbar_js.js cimbar_js.wasm index.html main.js)
 
-cd /usr/src/app
+cd $CIMBAR_ROOT
 mkdir build-asmjs
 cd build-asmjs
-emcmake cmake .. -DUSE_WASM=2 -DOPENCV_DIR=/usr/src/app/opencv4
+emcmake cmake .. -DUSE_WASM=2 -DOPENCV_DIR=$CIMBAR_ROOT/opencv4
 make -j5 install
 (cd ../web/ && zip cimbar.asmjs.zip cimbar_js.js index.html main.js)
 
-(cd ../ && python3 package-cimbar-html.py)
+(cd $CIMBAR_ROOT && python3 package-cimbar-html.py)
 

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
 	if (result.count("help"))
 	{
 		std::cerr << options.help() << std::endl;
-		exit(0);
+		return 0;
 	}
 
 	string outpath = std::experimental::filesystem::current_path();
@@ -211,10 +211,17 @@ int main(int argc, char** argv)
 
 	bool useStdin = !result.count("in");
 	vector<string> infiles;
-	if (useStdin)
-		std::cerr << "Enter input filenames:" << std::endl;
-	else
+	if (!useStdin)
+	{
 		infiles = result["in"].as<vector<string>>();
+		if (infiles.empty())
+		{
+			std::cerr << "No input files? :(" << std::endl;
+			return 128;
+		}
+	}
+	else
+		std::cerr << "Enter input filenames:" << std::endl;
 
 	bool encodeFlag = result.count("encode");
 	bool no_fountain = result.count("no-fountain");

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -29,9 +29,6 @@ extern "C" {
 
 int initialize_GL(int width, int height)
 {
-	if (_window)
-		return 1;
-
 	// must be divisible by 4???
 	if (width % 4 != 0)
 		width += (4 - width % 4);
@@ -39,7 +36,10 @@ int initialize_GL(int width, int height)
 		height += (4 - height % 4);
 	std::cerr << "initializing " << width << " by " << height << " window";
 
-	_window = std::make_shared<cimbar::window_glfw>(width, height, "Cimbar Encoder");
+	if (_window and _window->is_good())
+		_window->resize(width, height);
+	else
+		_window = std::make_shared<cimbar::window_glfw>(width, height, "Cimbar Encoder");
 	if (!_window or !_window->is_good())
 		return 0;
 

--- a/src/lib/fountain/test/CMakeLists.txt
+++ b/src/lib/fountain/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set (SOURCES
 	FountainEncodingTest.cpp
 	FountainMetadataTest.cpp
 	fountain_sinkTest.cpp
+	fountain_sinkSpecialTest.cpp
 	fountain_streamTest.cpp
 )
 

--- a/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
@@ -1,0 +1,93 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+
+#include "FountainMetadata.h"
+#include "fountain_encoder_stream.h"
+#include "fountain_decoder_sink.h"
+
+#include "serialize/format.h"
+#include "util/File.h"
+#include "util/MakeTempDirectory.h"
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using std::string;
+using namespace std;
+
+namespace {
+	stringstream dummyContents(unsigned size, string contents="0123456789")
+	{
+		stringstream input;
+		for (unsigned i = 0; i < (size/contents.size()); ++i)
+			input << contents;
+		return input;
+	}
+
+	string createFrame(fountain_encoder_stream& fes)
+	{
+		stringstream ss;
+		std::array<char, 125> buff;
+
+		// for a 7500 byte frame, 125*60 does the trick
+		for (int i = 0; i < 60; ++i)
+		{
+			unsigned res = fes.readsome(buff.data(), buff.size());
+			assertEquals( res, buff.size() );
+			ss << string(buff.data(), buff.size());
+		}
+		return ss.str();
+	}
+
+	std::string random_string(unsigned len, std::string chars="abcdefghijklmnaoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+	{
+		std::cout << ::rand() << std::endl;
+		std::string output = "";
+		for (unsigned i = 0; i < len; ++i)
+		{
+			unsigned idx = ::rand() % chars.length();
+			output += chars[idx];
+		}
+		return output;
+	}
+}
+
+TEST_CASE( "FountainSinkSpecialTest/testMultipart", "[unit]" )
+{
+	::srand( ::time(nullptr) );
+	MakeTempDirectory tempdir;
+
+	fountain_decoder_sink<std::ofstream> sink(tempdir.path(), 750);
+
+	const int totalSize = 6000000;
+	string randostr = random_string(2500);
+	std::cout << randostr << std::endl;
+	stringstream input = dummyContents(totalSize, randostr);
+	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 750, 108);
+
+	for (int i = 0; i < (totalSize / 7500) * 3; ++i)
+	{
+		string iframe = createFrame(*fes);
+		assertEquals( 7500, iframe.size() );
+
+		FountainMetadata md(iframe.data(), iframe.size());
+		assertEquals( totalSize, md.file_size() );
+		assertEquals( 108, md.encode_id() );
+
+		if (i % 2 == 1)
+		{
+			bool res = sink.decode_frame(iframe.data(), iframe.size());
+			//std::cout << i << ": " << res << std::endl;
+			assertMsg( ((i == 1613) == res), fmt::format("failed {}", i) );
+			assertMsg( ((i >= 1613) == sink.is_done(md.id())), fmt::format("failed {}", i) );
+		}
+	}
+
+	assertEquals( 0, sink.num_streams() );
+	assertEquals( 1, sink.num_done() );
+
+	string contents = File(tempdir.path() / fmt::format("108.{}", totalSize)).read_all();
+	assertEquals( totalSize, contents.size() );
+	assertEquals( input.str(), contents );
+}

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -44,9 +44,9 @@ protected:
 	}
 
 public:
-	gl_2d_display(unsigned width, unsigned height)
+	gl_2d_display(float dim)
 	    : _p(create())
-	    , _shakePos(computeShakePos(std::min(width, height)))
+	    , _shakePos(computeShakePos(dim))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -32,7 +32,7 @@ public:
 		glfwMakeContextCurrent(_w);
 		glfwSwapInterval(1);
 
-		_display = std::make_shared<cimbar::gl_2d_display>(width, height);
+		_display = std::make_shared<cimbar::gl_2d_display>(std::min(width, height));
 		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}
@@ -40,7 +40,10 @@ public:
 	~window_glfw()
 	{
 		if (_w)
+		{
 			glfwDestroyWindow(_w);
+			_w = nullptr;
+		}
 		if (_texid)
 			glDeleteTextures(1, &_texid);
 		glfwTerminate();
@@ -62,6 +65,12 @@ public:
 			return;
 		auto fun = [](GLFWwindow*, int w, int h){ glViewport(0, 0, w, h); };
 		glfwSetWindowSizeCallback(_w, fun);
+	}
+
+	void resize(unsigned width, unsigned height)
+	{
+		if (_w)
+			glfwSetWindowSize(_w, width, height);
 	}
 
 	void rotate(unsigned i=1)
@@ -127,7 +136,7 @@ protected:
 	}
 
 protected:
-	GLFWwindow* _w;
+	GLFWwindow* _w = nullptr;
 	GLuint _texid;
 	std::shared_ptr<cimbar::gl_2d_display> _display;
 	unsigned _width;


### PR DESCRIPTION
* small tweak to package-wasm script
* extra test case for fountain decoding (chasing a bug, but this doesn't seem to be it...)
* return an error code if no input files are specified in cimbar cli (seems good)
* some plumbing to  (eventually) allow different gl window sizes at runtime (i.e. swap barcode dimensions if different configs have different sizes)

This is preparation for merging a (separate) long-lived branch to allow more flexibility in config sizes.