### PR TITLE
non-square grid dimensions + miscellany

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,28 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         config:
         - name: "linux gcc9"
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           env: CXX="g++-9" CC="gcc-9"
 
         - name: "linux gcc-latest"
           os: ubuntu-latest
 
-        - name: "linux clang"
-          os: ubuntu-20.04
+        - name: "linux clang14"
+          os: ubuntu-22.04
+          env: CXX="clang++" CC="clang"
+          extra-packages: "clang"
+
+        - name: "linux clang-latest"
+          os: ubuntu-latest
           env: CXX="clang++" CC="clang"
           extra-packages: "clang"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
@@ -39,21 +44,21 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: make -j2 && make install
+      run: cmake --build . && cmake --install .
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
-      run: make test CTEST_OUTPUT_ON_FAILURE=TRUE
+      run: ctest --output-on-failure
 
     - name: Usage test
       working-directory: ${{runner.workspace}}/libcimbar/test/py
       run: python3 -m unittest
 
   cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: sudo apt-get install cppcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/src/exe/build_image_assets/build_image_assets.cpp
+++ b/src/exe/build_image_assets/build_image_assets.cpp
@@ -20,7 +20,7 @@ map<string, string> getFileBlobs(string dir_path)
 	map<string, string> blobs;
 
 	vector<string> anchors = {"anchor-{}.png", "anchor-secondary-{}.png", "guide-horizontal-{}.png", "guide-vertical-{}.png"};
-	for (const string& mode : {"light", "dark"})
+	for (const auto& mode : {"light", "dark"})
 		for (const string& a : anchors)
 		{
 			string short_path = fmt::format(a, mode);

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -104,6 +104,7 @@ template <typename FilenameIterable>
 int encode(const FilenameIterable& infiles, const std::string& outpath, int ecc, int color_bits, int compression_level, bool legacy_mode, bool no_fountain)
 {
 	Encoder en(ecc, cimbar::Config::symbol_bits(), color_bits);
+	en.set_encode_id(109);
 	if (legacy_mode)
 		en.set_legacy_mode();
 	for (const string& f : infiles)

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
 		std::cerr << "failed to create window :(" << std::endl;
 		return 70;
 	}
-
+	auto_scale_window();
 	configure(colorBits, ecc, compressionLevel, legacy_mode);
 
 	std::chrono::time_point start = std::chrono::high_resolution_clock::now();

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -75,8 +75,9 @@ int main(int argc, char** argv)
 		fps = defaultFps;
 	unsigned delay = 1000 / fps;
 
-	int window_size = cimbar::Config::image_size() + 32;
-	if (!initialize_GL(window_size, window_size))
+	int window_size_x = cimbar::Config::image_size_x() + 32;
+	int window_size_y = cimbar::Config::image_size_y() + 32;
+	if (!initialize_GL(window_size_x, window_size_y))
 	{
 		std::cerr << "failed to create window :(" << std::endl;
 		return 70;

--- a/src/lib/bit_file/bitreader.h
+++ b/src/lib/bit_file/bitreader.h
@@ -88,7 +88,7 @@ public:
 		return bits;
 	}
 
-	std::tuple<unsigned, unsigned> bytes_and_bits(unsigned how_many_bits, unsigned bitoffset) const
+	std::tuple<unsigned, unsigned> bytes_and_bits(unsigned how_many_bits) const
 	{
 		unsigned remainder_bits = how_many_bits % 8;
 		unsigned bytes = how_many_bits / 8;

--- a/src/lib/bit_file/test/CMakeLists.txt
+++ b/src/lib/bit_file/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(bit_file_test)
 

--- a/src/lib/cimb_translator/AdjacentCellFinder.cpp
+++ b/src/lib/cimb_translator/AdjacentCellFinder.cpp
@@ -1,14 +1,14 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #include "AdjacentCellFinder.h"
 
-AdjacentCellFinder::AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions_x, int dimensions_y, int marker_size_x, int marker_size_y)
+AdjacentCellFinder::AdjacentCellFinder(const CellPositions::positions_list& positions, cimbar::vec_xy dimensions, cimbar::vec_xy marker_size)
 	: _positions(positions)
-	, _dimensionsX(dimensions_x)
-	, _markerSizeX(marker_size_x)
+	, _dimensionsX(dimensions.x)
+	, _markerSizeX(marker_size.x)
 {
-	int midHeight = dimensions_y - marker_size_y - marker_size_y;
-	int midCells = dimensions_x * midHeight;
-	int edgeCells = calc_mid_width() * marker_size_y;
+	int midHeight = dimensions.y - marker_size.y - marker_size.y;
+	int midCells = dimensions.x * midHeight;
+	int edgeCells = calc_mid_width() * marker_size.y;
 	_firstMid = edgeCells;
 	_firstBottom = edgeCells + midCells;
 }

--- a/src/lib/cimb_translator/AdjacentCellFinder.cpp
+++ b/src/lib/cimb_translator/AdjacentCellFinder.cpp
@@ -1,14 +1,14 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #include "AdjacentCellFinder.h"
 
-AdjacentCellFinder::AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions, int marker_size)
+AdjacentCellFinder::AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions_x, int dimensions_y, int marker_size_x, int marker_size_y)
 	: _positions(positions)
-	, _dimensions(dimensions)
-	, _markerSize(marker_size)
+	, _dimensionsX(dimensions_x)
+	, _markerSizeX(marker_size_x)
 {
-	int midDimensions = dimensions - marker_size - marker_size;
-	int midCells = dimensions * midDimensions;
-	int edgeCells = midDimensions * marker_size;
+	int midHeight = dimensions_y - marker_size_y - marker_size_y;
+	int midCells = dimensions_x * midHeight;
+	int edgeCells = calc_mid_width() * marker_size_y;
 	_firstMid = edgeCells;
 	_firstBottom = edgeCells + midCells;
 }
@@ -21,14 +21,24 @@ std::array<int, 4> AdjacentCellFinder::find(int index) const
 	return adj;
 }
 
-int AdjacentCellFinder::dimensions() const
+int AdjacentCellFinder::dimensions_x() const
 {
-	return _dimensions;
+	return _dimensionsX;
 }
 
-int AdjacentCellFinder::marker_size() const
+int AdjacentCellFinder::marker_size_x() const
 {
-	return _markerSize;
+	return _markerSizeX;
+}
+
+int AdjacentCellFinder::calc_mid_width() const
+{
+	return _dimensionsX - _markerSizeX - _markerSizeX;
+}
+
+int AdjacentCellFinder::first_mid() const
+{
+	return _firstMid;
 }
 
 int AdjacentCellFinder::in_row_with_margin(int index) const
@@ -65,12 +75,12 @@ int AdjacentCellFinder::bottom(int index) const
 {
 	if (index < 0 || index >= (int)_positions.size())
 		return -1;
-	int increment = _dimensions;
+	int increment = _dimensionsX;
 	if (in_row_with_margin(index))
-		increment -= _markerSize;
+		increment -= _markerSizeX;
 	int next = index + increment;
 	if (in_row_with_margin(next))
-		next -= _markerSize;
+		next -= _markerSizeX;
 	if (next < 0 || next >= (int)_positions.size())
 		return -1;
 	if (_positions[next].first != _positions[index].first)
@@ -80,12 +90,12 @@ int AdjacentCellFinder::bottom(int index) const
 
 int AdjacentCellFinder::top(int index) const
 {
-	int increment = _dimensions;
+	int increment = _dimensionsX;
 	if (in_row_with_margin(index))
-		increment -= _markerSize;
+		increment -= _markerSizeX;
 	int next = index - increment;
 	if (in_row_with_margin(next))
-		next += _markerSize;
+		next += _markerSizeX;
 
 	if (next < 0)
 		return -1;

--- a/src/lib/cimb_translator/AdjacentCellFinder.h
+++ b/src/lib/cimb_translator/AdjacentCellFinder.h
@@ -7,12 +7,15 @@
 class AdjacentCellFinder
 {
 public:
-	AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions, int marker_size);
+	AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions_x, int dimensions_y, int marker_size_x, int marker_size_y);
 
 	std::array<int, 4> find(int index) const;
 
-	int dimensions() const;
-	int marker_size() const;
+	int dimensions_x() const;
+	int marker_size_x() const;
+	int calc_mid_width() const;
+
+	int first_mid() const;
 
 	int right(int index) const;
 	int left(int index) const;
@@ -24,8 +27,8 @@ protected:
 
 protected:
 	const CellPositions::positions_list& _positions;
-	int _dimensions;
-	int _markerSize;
+	int _dimensionsX;
+	int _markerSizeX;
 	int _firstMid;
 	int _firstBottom;
 };

--- a/src/lib/cimb_translator/AdjacentCellFinder.h
+++ b/src/lib/cimb_translator/AdjacentCellFinder.h
@@ -2,12 +2,13 @@
 #pragma once
 
 #include "CellPositions.h"
+#include "util/vec_xy.h"
 #include <array>
 
 class AdjacentCellFinder
 {
 public:
-	AdjacentCellFinder(const CellPositions::positions_list& positions, int dimensions_x, int dimensions_y, int marker_size_x, int marker_size_y);
+	AdjacentCellFinder(const CellPositions::positions_list& positions, cimbar::vec_xy dimensions, cimbar::vec_xy marker_size);
 
 	std::array<int, 4> find(int index) const;
 

--- a/src/lib/cimb_translator/Cell.h
+++ b/src/lib/cimb_translator/Cell.h
@@ -39,20 +39,20 @@ public:
 		const uchar* p = _img.ptr<uchar>(0) + (index * channels);
 
 		int increment = 1 + skip;
-		int toNextCol = channels * (_img.rows - _rows);
+		int toNextRow = channels * (_img.cols - _cols);
 		if (skip)
-			toNextCol += channels * _img.rows;
+			toNextRow += channels * _img.cols;
 
-		for (int i = 0; i < _cols; i+=increment)
+		for (int i = 0; i < _rows; i+=increment)
 		{
-			for (int j = 0; j < _rows; ++j, ++count)
+			for (int j = 0; j < _cols; ++j, ++count)
 			{
 				red += p[0];
 				green += p[1];
 				blue += p[2];
 				p += channels;
 			}
-			p += toNextCol;
+			p += toNextRow;
 		}
 
 		if (!count)

--- a/src/lib/cimb_translator/CellPositions.cpp
+++ b/src/lib/cimb_translator/CellPositions.cpp
@@ -2,7 +2,7 @@
 #include "CellPositions.h"
 #include "Interleave.h"
 
-CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size)
+CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
 {
 	/*
 	 * ex: if dimensions == 128, and marker_size == 8:
@@ -16,48 +16,49 @@ CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int s
 	*/
 	positions_list res;
 	int offset_y = offset;
-	int marker_offset_x = std::max(spacing_x, spacing_y) * marker_size;
-	int top_width = dimensions - marker_size - marker_size;
-	int top_cells = top_width * marker_size;
+	int marker_offset_x = spacing_x * marker_size_x;
+	int top_width = dimensions_x - marker_size_x - marker_size_x;
+	int top_cells = top_width * marker_size_y;
 	for (int i = 0; i < top_cells; ++i)
 	{
-		int x = (i % top_width) * spacing + marker_offset_x + offset;
-		int y = (i / top_width) * spacing + offset_y;
+		int x = (i % top_width) * spacing_x + marker_offset_x + offset;
+		int y = (i / top_width) * spacing_y + offset_y;
 		res.push_back({x, y});
 	}
 
-	int mid_y = marker_size * spacing;
-	int mid_width = dimensions;
-	int mid_cells = mid_width * top_width;  // top_width is also "mid_height"
+	int mid_y = marker_size_y * spacing_y;
+	int mid_width = dimensions_x;
+	int mid_height = dimensions_y - marker_size_y - marker_size_y;
+	int mid_cells = mid_width * mid_height;
 	for (int i = 0; i < mid_cells; ++i)
 	{
-		int x = (i % mid_width) * spacing + offset;
-		int y = (i / mid_width) * spacing + mid_y + offset_y;
+		int x = (i % mid_width) * spacing_x + offset;
+		int y = (i / mid_width) * spacing_y + mid_y + offset_y;
 		res.push_back({x, y});
 	}
 
-	int bottom_y = (dimensions - marker_size) * spacing;
+	int bottom_y = (dimensions_y - marker_size_y) * spacing_y;
 	int bottom_width = top_width;
-	int bottom_cells = bottom_width * marker_size;
+	int bottom_cells = bottom_width * marker_size_y;
 	for (int i = 0; i < bottom_cells; ++i)
 	{
-		int x = (i % bottom_width) * spacing + marker_offset_x + offset;
-		int y = (i / bottom_width) * spacing + bottom_y + offset_y;
+		int x = (i % bottom_width) * spacing_x + marker_offset_x + offset;
+		int y = (i / bottom_width) * spacing_y + bottom_y + offset_y;
 		res.push_back({x, y});
 	}
 	return res;
 }
 
-CellPositions::positions_list CellPositions::compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size, int interleave_blocks, int interleave_partitions)
+CellPositions::positions_list CellPositions::compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks, int interleave_partitions)
 {
-	CellPositions::positions_list pos = compute_linear(spacing, dimensions, offset, marker_size);
+	CellPositions::positions_list pos = compute_linear(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y);
 	if (interleave_blocks)
 		return Interleave::interleave(pos, interleave_blocks, interleave_partitions);
 	return pos;
 }
 
-CellPositions::CellPositions(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks, int interleave_partitions)
-	: _positions(compute(spacing, dimensions, offset, marker_size, interleave_blocks, interleave_partitions))
+CellPositions::CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks, int interleave_partitions)
+	: _positions(compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, interleave_blocks, interleave_partitions))
 {
 	reset();
 }

--- a/src/lib/cimb_translator/CellPositions.cpp
+++ b/src/lib/cimb_translator/CellPositions.cpp
@@ -2,7 +2,7 @@
 #include "CellPositions.h"
 #include "Interleave.h"
 
-CellPositions::positions_list CellPositions::compute_linear(int spacing, int dimensions, int offset, int marker_size)
+CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size)
 {
 	/*
 	 * ex: if dimensions == 128, and marker_size == 8:
@@ -16,7 +16,7 @@ CellPositions::positions_list CellPositions::compute_linear(int spacing, int dim
 	*/
 	positions_list res;
 	int offset_y = offset;
-	int marker_offset_x = spacing * marker_size;
+	int marker_offset_x = std::max(spacing_x, spacing_y) * marker_size;
 	int top_width = dimensions - marker_size - marker_size;
 	int top_cells = top_width * marker_size;
 	for (int i = 0; i < top_cells; ++i)
@@ -48,7 +48,7 @@ CellPositions::positions_list CellPositions::compute_linear(int spacing, int dim
 	return res;
 }
 
-CellPositions::positions_list CellPositions::compute(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks, int interleave_partitions)
+CellPositions::positions_list CellPositions::compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size, int interleave_blocks, int interleave_partitions)
 {
 	CellPositions::positions_list pos = compute_linear(spacing, dimensions, offset, marker_size);
 	if (interleave_blocks)
@@ -57,7 +57,7 @@ CellPositions::positions_list CellPositions::compute(int spacing, int dimensions
 }
 
 CellPositions::CellPositions(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks, int interleave_partitions)
-    : _positions(compute(spacing, dimensions, offset, marker_size, interleave_blocks, interleave_partitions))
+	: _positions(compute(spacing, dimensions, offset, marker_size, interleave_blocks, interleave_partitions))
 {
 	reset();
 }

--- a/src/lib/cimb_translator/CellPositions.cpp
+++ b/src/lib/cimb_translator/CellPositions.cpp
@@ -2,7 +2,7 @@
 #include "CellPositions.h"
 #include "Interleave.h"
 
-CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
+CellPositions::positions_list CellPositions::compute_linear(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size)
 {
 	/*
 	 * ex: if dimensions == 128, and marker_size == 8:
@@ -16,49 +16,49 @@ CellPositions::positions_list CellPositions::compute_linear(int spacing_x, int s
 	*/
 	positions_list res;
 	int offset_y = offset;
-	int marker_offset_x = spacing_x * marker_size_x;
-	int top_width = dimensions_x - marker_size_x - marker_size_x;
-	int top_cells = top_width * marker_size_y;
+	int marker_offset_x = spacing.x * marker_size.x;
+	int top_width = dimensions.x - marker_size.x - marker_size.x;
+	int top_cells = top_width * marker_size.y;
 	for (int i = 0; i < top_cells; ++i)
 	{
-		int x = (i % top_width) * spacing_x + marker_offset_x + offset;
-		int y = (i / top_width) * spacing_y + offset_y;
+		int x = (i % top_width) * spacing.x + marker_offset_x + offset;
+		int y = (i / top_width) * spacing.y + offset_y;
 		res.push_back({x, y});
 	}
 
-	int mid_y = marker_size_y * spacing_y;
-	int mid_width = dimensions_x;
-	int mid_height = dimensions_y - marker_size_y - marker_size_y;
+	int mid_y = marker_size.y * spacing.y;
+	int mid_width = dimensions.x;
+	int mid_height = dimensions.y - marker_size.y - marker_size.y;
 	int mid_cells = mid_width * mid_height;
 	for (int i = 0; i < mid_cells; ++i)
 	{
-		int x = (i % mid_width) * spacing_x + offset;
-		int y = (i / mid_width) * spacing_y + mid_y + offset_y;
+		int x = (i % mid_width) * spacing.x + offset;
+		int y = (i / mid_width) * spacing.y + mid_y + offset_y;
 		res.push_back({x, y});
 	}
 
-	int bottom_y = (dimensions_y - marker_size_y) * spacing_y;
+	int bottom_y = (dimensions.y - marker_size.y) * spacing.y;
 	int bottom_width = top_width;
-	int bottom_cells = bottom_width * marker_size_y;
+	int bottom_cells = bottom_width * marker_size.y;
 	for (int i = 0; i < bottom_cells; ++i)
 	{
-		int x = (i % bottom_width) * spacing_x + marker_offset_x + offset;
-		int y = (i / bottom_width) * spacing_y + bottom_y + offset_y;
+		int x = (i % bottom_width) * spacing.x + marker_offset_x + offset;
+		int y = (i / bottom_width) * spacing.y + bottom_y + offset_y;
 		res.push_back({x, y});
 	}
 	return res;
 }
 
-CellPositions::positions_list CellPositions::compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks, int interleave_partitions)
+CellPositions::positions_list CellPositions::compute(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size, int interleave_blocks, int interleave_partitions)
 {
-	CellPositions::positions_list pos = compute_linear(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y);
+	CellPositions::positions_list pos = compute_linear(spacing, dimensions, offset, marker_size);
 	if (interleave_blocks)
 		return Interleave::interleave(pos, interleave_blocks, interleave_partitions);
 	return pos;
 }
 
-CellPositions::CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks, int interleave_partitions)
-	: _positions(compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, interleave_blocks, interleave_partitions))
+CellPositions::CellPositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size, int interleave_blocks, int interleave_partitions)
+	: _positions(compute(spacing, dimensions, offset, marker_size, interleave_blocks, interleave_partitions))
 {
 	reset();
 }

--- a/src/lib/cimb_translator/CellPositions.h
+++ b/src/lib/cimb_translator/CellPositions.h
@@ -15,7 +15,7 @@ public:
 	static positions_list compute(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks=0, int interleave_partitions=1);
 
 public:
-	CellPositions(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks=0, int interleave_partitions=1);
+	CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size, int interleave_blocks=0, int interleave_partitions=1);
 
 	unsigned index() const;
 	size_t count() const;

--- a/src/lib/cimb_translator/CellPositions.h
+++ b/src/lib/cimb_translator/CellPositions.h
@@ -11,11 +11,11 @@ public:
 	using coordinate = std::pair<int, int>;
 	using positions_list = std::vector<coordinate>;
 
-	static positions_list compute_linear(int spacing, int dimensions, int offset, int marker_size);
-	static positions_list compute(int spacing, int dimensions, int offset, int marker_size, int interleave_blocks=0, int interleave_partitions=1);
+	static positions_list compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
+	static positions_list compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks=0, int interleave_partitions=1);
 
 public:
-	CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size, int interleave_blocks=0, int interleave_partitions=1);
+	CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks=0, int interleave_partitions=1);
 
 	unsigned index() const;
 	size_t count() const;

--- a/src/lib/cimb_translator/CellPositions.h
+++ b/src/lib/cimb_translator/CellPositions.h
@@ -1,6 +1,7 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #pragma once
 
+#include "util/vec_xy.h"
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -11,11 +12,11 @@ public:
 	using coordinate = std::pair<int, int>;
 	using positions_list = std::vector<coordinate>;
 
-	static positions_list compute_linear(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
-	static positions_list compute(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks=0, int interleave_partitions=1);
+	static positions_list compute_linear(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size);
+	static positions_list compute(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size, int interleave_blocks=0, int interleave_partitions=1);
 
 public:
-	CellPositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y, int interleave_blocks=0, int interleave_partitions=1);
+	CellPositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size,int interleave_blocks=0, int interleave_partitions=1);
 
 	unsigned index() const;
 	size_t count() const;

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -94,7 +94,7 @@ CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_
 	: _image(img)
 	, _fountainColorHeader(0U)
 	, _cellSize(Config::cell_size() + 2)
-	, _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding())
+	, _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding_x(), Config::corner_padding_y())
 	, _decoder(decoder)
 	, _good(_image.cols >= Config::image_size() and _image.rows >= Config::image_size())
 	, _colorCorrection(color_correction)

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -94,7 +94,7 @@ CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_
 	: _image(img)
 	, _fountainColorHeader(0U)
 	, _cellSize(Config::cell_size() + 2)
-	, _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding())
+	, _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding())
 	, _decoder(decoder)
 	, _good(_image.cols >= Config::image_size() and _image.rows >= Config::image_size())
 	, _colorCorrection(color_correction)

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -98,7 +98,11 @@ CimbReader::CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_
 	: _image(img)
 	, _fountainColorHeader(0U)
 	, _cellSize(Config::cell_size() + 2)
-	, _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding_x(), Config::corner_padding_y())
+	, _positions(
+		  cimbar::vec_xy{Config::cell_spacing_x(), Config::cell_spacing_y()},
+		  cimbar::vec_xy{Config::cells_per_col_x(), Config::cells_per_col_y()},
+		  Config::cell_offset(), cimbar::vec_xy{Config::corner_padding_x(), Config::corner_padding_y()}
+	)
 	, _decoder(decoder)
 	, _good(_image.cols >= Config::image_size_x() and _image.rows >= Config::image_size_y())
 	, _colorCorrection(color_correction)

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -36,7 +36,7 @@ namespace {
 }
 
 CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int size)
-	: _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
+	: _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding_x(), Config::corner_padding_y(), Config::interleave_blocks(), Config::interleave_partitions())
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
 	if (size > cimbar::Config::image_size())

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -36,7 +36,7 @@ namespace {
 }
 
 CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int size)
-	: _positions(Config::cell_spacing(), Config::cells_per_col(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
+	: _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding(), Config::interleave_blocks(), Config::interleave_partitions())
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
 	if (size > cimbar::Config::image_size())

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -36,12 +36,12 @@ namespace {
 	}
 }
 
-CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, int width, int height)
+CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, vec_xy size)
 	: _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding_x(), Config::corner_padding_y(), Config::interleave_blocks(), Config::interleave_partitions())
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
-	height = std::max(height, cimbar::Config::image_size_y());
-	width = std::max(width, cimbar::Config::image_size_x());
+	int height = std::max(size.height(), cimbar::Config::image_size_y());
+	int width = std::max(size.width(), cimbar::Config::image_size_x());
 
 	_offsetX = (width - cimbar::Config::image_size_x()) / 2;
 	_offsetY = (height - cimbar::Config::image_size_y()) / 2;

--- a/src/lib/cimb_translator/CimbWriter.cpp
+++ b/src/lib/cimb_translator/CimbWriter.cpp
@@ -37,11 +37,15 @@ namespace {
 }
 
 CimbWriter::CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark, unsigned color_mode, vec_xy size)
-	: _positions(Config::cell_spacing_x(), Config::cell_spacing_y(), Config::cells_per_col_x(), Config::cells_per_col_y(), Config::cell_offset(), Config::corner_padding_x(), Config::corner_padding_y(), Config::interleave_blocks(), Config::interleave_partitions())
+	: _positions(
+		  cimbar::vec_xy{Config::cell_spacing_x(), Config::cell_spacing_y()},
+		  cimbar::vec_xy{Config::cells_per_col_x(), Config::cells_per_col_y()},
+		  Config::cell_offset(), cimbar::vec_xy{Config::corner_padding_x(), Config::corner_padding_y()},
+		  Config::interleave_blocks(), Config::interleave_partitions())
 	, _encoder(symbol_bits, color_bits, dark, color_mode)
 {
-	int height = std::max(size.height(), cimbar::Config::image_size_y());
-	int width = std::max(size.width(), cimbar::Config::image_size_x());
+	unsigned height = std::max(size.height(), cimbar::Config::image_size_y());
+	unsigned width = std::max(size.width(), cimbar::Config::image_size_x());
 
 	_offsetX = (width - cimbar::Config::image_size_x()) / 2;
 	_offsetY = (height - cimbar::Config::image_size_y()) / 2;

--- a/src/lib/cimb_translator/CimbWriter.h
+++ b/src/lib/cimb_translator/CimbWriter.h
@@ -3,11 +3,12 @@
 
 #include "CellPositions.h"
 #include "CimbEncoder.h"
+#include "util/vec_xy.h"
 
 class CimbWriter
 {
 public:
-	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1, int width=0, int height=0);
+	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1, cimbar::vec_xy size={});
 
 	bool write(unsigned bits);
 	bool done() const;

--- a/src/lib/cimb_translator/CimbWriter.h
+++ b/src/lib/cimb_translator/CimbWriter.h
@@ -7,7 +7,7 @@
 class CimbWriter
 {
 public:
-	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1, int size=0);
+	CimbWriter(unsigned symbol_bits, unsigned color_bits, bool dark=true, unsigned color_mode=1, int width=0, int height=0);
 
 	bool write(unsigned bits);
 	bool done() const;
@@ -23,5 +23,6 @@ protected:
 	cv::Mat _image;
 	CellPositions _positions;
 	CimbEncoder _encoder;
-	unsigned _offset = 0;
+	unsigned _offsetX = 0;
+	unsigned _offsetY = 0;
 };

--- a/src/lib/cimb_translator/Common.cpp
+++ b/src/lib/cimb_translator/Common.cpp
@@ -25,7 +25,7 @@ namespace {
 			RGB(0, 0xFF, 0),
 			RGB(0, 0xFF, 0xFF),
 			RGB(0xFF, 0xFF, 0),
-			RGB(0xFF, 0, 0xFF),
+			RGB(0xFF, 0x55, 0xFF), // 0x55
 		};
 		return colors[index];
 	}
@@ -70,6 +70,18 @@ namespace {
 		};
 		return colors[index];
 	}
+
+	RGB getBgColor4(unsigned index)
+	{
+		// opencv uses BGR, but we don't have to conform to its tyranny
+		static constexpr array<RGB, 4> colors = {
+			RGB(0, 0x20, 0),
+			RGB(0, 0, 0xFF),
+			RGB(0x7F, 0, 0),
+			RGB(0, 0, 0),
+		};
+		return colors[index];
+	}
 }
 
 namespace cimbar {
@@ -109,7 +121,18 @@ RGB getColor(unsigned index, unsigned num_colors, unsigned color_mode)
 		return getColor4(index);
 	else
 		return getColor8(index);
+}
 
+RGB getBgColor(unsigned index, unsigned num_colors, unsigned color_mode)
+{
+	// light mode
+	if (color_mode >= 100)
+		return RGB(0xFF, 0xFF, 0xFF);
+
+	if (color_mode == 1 and num_colors <= 4)
+		return getBgColor4(index);
+	else
+		return RGB(0,0,0);
 }
 
 cv::Mat getTile(unsigned symbol_bits, unsigned symbol, bool dark, unsigned num_colors, unsigned color, unsigned color_mode)
@@ -121,17 +144,16 @@ cv::Mat getTile(unsigned symbol_bits, unsigned symbol, bool dark, unsigned num_c
 
 	uchar r, g, b;
 	std::tie(r, g, b) = getColor(color, num_colors, color_mode);
+	uchar bgr, bgg, bgb;
+	std::tie(bgr, bgg, bgb) = getBgColor(color, num_colors, color_mode);
 	cv::MatIterator_<cv::Vec3b> end = tile.end<cv::Vec3b>();
 	for (cv::MatIterator_<cv::Vec3b> it = tile.begin<cv::Vec3b>(); it != end; ++it)
 	{
 		cv::Vec3b& c = *it;
 		if (c == background)
-		{
-			if (dark)
-				c = {0, 0, 0};
-			continue;
-		}
-		c = {r, g, b};
+			c = {bgr, bgg, bgb};
+		else
+			c = {r, g, b};
 	}
 	return tile;
 }

--- a/src/lib/cimb_translator/Common.cpp
+++ b/src/lib/cimb_translator/Common.cpp
@@ -25,7 +25,7 @@ namespace {
 			RGB(0, 0xFF, 0),
 			RGB(0, 0xFF, 0xFF),
 			RGB(0xFF, 0xFF, 0),
-			RGB(0xFF, 0x55, 0xFF), // 0x55
+			RGB(0xFF, 0, 0xFF), // RGB(0xFF, 0x55, 0xFF),
 		};
 		return colors[index];
 	}
@@ -75,9 +75,9 @@ namespace {
 	{
 		// opencv uses BGR, but we don't have to conform to its tyranny
 		static constexpr array<RGB, 4> colors = {
-			RGB(0, 0x20, 0),
-			RGB(0, 0, 0xFF),
-			RGB(0x7F, 0, 0),
+			RGB(0, 0, 0), //RGB(0, 0x20, 0),
+			RGB(0, 0, 0),//RGB(0, 0, 0xFF),
+			RGB(0, 0, 0), //RGB(0x7F, 0, 0),
 			RGB(0, 0, 0),
 		};
 		return colors[index];
@@ -125,9 +125,6 @@ RGB getColor(unsigned index, unsigned num_colors, unsigned color_mode)
 
 RGB getBgColor(unsigned index, unsigned num_colors, unsigned color_mode)
 {
-	// light mode
-	if (color_mode >= 100)
-		return RGB(0xFF, 0xFF, 0xFF);
 
 	if (color_mode == 1 and num_colors <= 4)
 		return getBgColor4(index);
@@ -150,10 +147,10 @@ cv::Mat getTile(unsigned symbol_bits, unsigned symbol, bool dark, unsigned num_c
 	for (cv::MatIterator_<cv::Vec3b> it = tile.begin<cv::Vec3b>(); it != end; ++it)
 	{
 		cv::Vec3b& c = *it;
-		if (c == background)
-			c = {bgr, bgg, bgb};
-		else
+		if (c != background)
 			c = {r, g, b};
+		else if (dark)
+			c = {bgr, bgg, bgb};
 	}
 	return tile;
 }

--- a/src/lib/cimb_translator/Config.cpp
+++ b/src/lib/cimb_translator/Config.cpp
@@ -6,7 +6,7 @@ namespace cimbar {
 
 unsigned Config::total_cells()
 {
-	return std::pow(cells_per_col(), 2) - std::pow(corner_padding(), 2) * 4;
+	return cells_per_col_x()*cells_per_col_y() - (corner_padding_x()*corner_padding_y() * 4);
 }
 
 unsigned Config::decode_window_bits()
@@ -21,9 +21,14 @@ unsigned Config::capacity(unsigned bitspercell)
 	return total_cells() * bitspercell / 8;
 }
 
-unsigned Config::corner_padding()
+unsigned Config::corner_padding_x()
 {
-	return lrint(54.0 / cell_spacing());
+	return lrint(54.0 / cell_spacing_x());
+}
+
+unsigned Config::corner_padding_y()
+{
+	return lrint(54.0 / cell_spacing_y());
 }
 
 unsigned Config::fountain_chunk_size(unsigned ecc, unsigned bitspercell, bool legacy_mode)

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -8,7 +8,7 @@ namespace cimbar
 	class Config
 	{
 	protected:
-		using GridConf = Conf8x8;
+		using GridConf = Conf5x5;
 
 	public:
 		static constexpr bool dark()
@@ -61,9 +61,14 @@ namespace cimbar
 			return GridConf::cell_size;
 		}
 
-		static constexpr unsigned cell_spacing()
+		static constexpr unsigned cell_spacing_x()
 		{
-			return cell_size() + 1;
+			return GridConf::cell_spacing_x;
+		}
+
+		static constexpr unsigned cell_spacing_y()
+		{
+			return GridConf::cell_spacing_y;
 		}
 
 		static unsigned corner_padding();
@@ -73,9 +78,14 @@ namespace cimbar
 			return GridConf::cell_offset;
 		}
 
-		static constexpr unsigned cells_per_col()
+		static constexpr unsigned cells_per_col_x()
 		{
-			return GridConf::cells_per_col;
+			return GridConf::cells_per_col_x;
+		}
+
+		static constexpr unsigned cells_per_col_y()
+		{
+			return GridConf::cells_per_col_y;
 		}
 
 		static unsigned total_cells();

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -8,7 +8,7 @@ namespace cimbar
 	class Config
 	{
 	protected:
-		using GridConf = Conf5x5d;
+		using GridConf = Conf8x8;
 
 	public:
 		static constexpr bool dark()
@@ -46,9 +46,14 @@ namespace cimbar
 			return GridConf::ecc_block_size;
 		}
 
-		static constexpr int image_size()
+		static constexpr int image_size_x()
 		{
-			return GridConf::image_size;
+			return GridConf::image_size_x;
+		}
+
+		static constexpr int image_size_y()
+		{
+			return GridConf::image_size_y;
 		}
 
 		static constexpr unsigned anchor_size()

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -8,7 +8,7 @@ namespace cimbar
 	class Config
 	{
 	protected:
-		using GridConf = Conf8x8;
+		using GridConf = Conf5x5d;
 
 	public:
 		static constexpr bool dark()
@@ -108,7 +108,9 @@ namespace cimbar
 
 		static constexpr unsigned fountain_chunks_per_frame(unsigned bitspercell, bool legacy_mode)
 		{
-			return legacy_mode? 10 : bitspercell << 1;
+			if (legacy_mode or !GridConf::fountain_chunks_per_frame)
+				return 10;
+			return bitspercell * GridConf::fountain_chunks_per_frame;
 		}
 
 		static unsigned fountain_chunk_size(unsigned ecc, unsigned bitspercell, bool legacy_mode);

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -8,7 +8,7 @@ namespace cimbar
 	class Config
 	{
 	protected:
-		using GridConf = Conf5x5;
+		using GridConf = Conf8x8;
 
 	public:
 		static constexpr bool dark()
@@ -71,7 +71,9 @@ namespace cimbar
 			return GridConf::cell_spacing_y;
 		}
 
-		static unsigned corner_padding();
+		static unsigned corner_padding_x();
+
+		static unsigned corner_padding_y();
 
 		static constexpr unsigned cell_offset()
 		{

--- a/src/lib/cimb_translator/Config.h
+++ b/src/lib/cimb_translator/Config.h
@@ -46,12 +46,12 @@ namespace cimbar
 			return GridConf::ecc_block_size;
 		}
 
-		static constexpr int image_size_x()
+		static constexpr unsigned image_size_x()
 		{
 			return GridConf::image_size_x;
 		}
 
-		static constexpr int image_size_y()
+		static constexpr unsigned image_size_y()
 		{
 			return GridConf::image_size_y;
 		}

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -2,9 +2,9 @@
 #include "FloodDecodePositions.h"
 #include <iostream>
 
-FloodDecodePositions::FloodDecodePositions(int spacing, int dimensions, int offset, int marker_size)
-	: _positions(CellPositions::compute(spacing, dimensions, offset, marker_size, 0))
-	, _cellFinder(_positions, dimensions, marker_size)
+FloodDecodePositions::FloodDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
+	: _positions(CellPositions::compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, 0))
+	, _cellFinder(_positions, dimensions_x, dimensions_y, marker_size_x, marker_size_y)
 {
 	reset();
 }
@@ -26,7 +26,7 @@ void FloodDecodePositions::reset()
 	}
 
 	// seed
-	uint16_t smallRowLen = _cellFinder.dimensions() - (2*_cellFinder.marker_size());
+	uint16_t smallRowLen = _cellFinder.calc_mid_width();
 	uint16_t lastElem = _positions.size()-1;
 	_heap.push({0, 0});
 	_heap.push({smallRowLen-1, 0});
@@ -34,11 +34,11 @@ void FloodDecodePositions::reset()
 	_heap.push({lastElem-(smallRowLen-1), 0});
 
 	// add more seed corners?
-	uint16_t betweenMarkerBlock = smallRowLen * _cellFinder.marker_size();
+	uint16_t betweenMarkerBlock = _cellFinder.first_mid();
 	_heap.push({betweenMarkerBlock, 1});
-	_heap.push({betweenMarkerBlock+_cellFinder.dimensions()-1, 1});
+	_heap.push({betweenMarkerBlock+_cellFinder.dimensions_x()-1, 1});
 	_heap.push({lastElem-betweenMarkerBlock, 1});
-	_heap.push({lastElem-(betweenMarkerBlock+_cellFinder.dimensions()-1), 1});
+	_heap.push({lastElem-(betweenMarkerBlock+_cellFinder.dimensions_x()-1), 1});
 }
 
 bool FloodDecodePositions::done() const

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -2,9 +2,9 @@
 #include "FloodDecodePositions.h"
 #include <iostream>
 
-FloodDecodePositions::FloodDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
-	: _positions(CellPositions::compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, 0))
-	, _cellFinder(_positions, dimensions_x, dimensions_y, marker_size_x, marker_size_y)
+FloodDecodePositions::FloodDecodePositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size)
+	: _positions(CellPositions::compute(spacing, dimensions, offset, marker_size, 0))
+	, _cellFinder(_positions, dimensions, marker_size)
 {
 	reset();
 }

--- a/src/lib/cimb_translator/FloodDecodePositions.h
+++ b/src/lib/cimb_translator/FloodDecodePositions.h
@@ -28,7 +28,7 @@ public:
 	};
 
 public:
-	FloodDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
+	FloodDecodePositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size);
 
 	size_t size() const;
 	void reset();

--- a/src/lib/cimb_translator/FloodDecodePositions.h
+++ b/src/lib/cimb_translator/FloodDecodePositions.h
@@ -28,7 +28,7 @@ public:
 	};
 
 public:
-	FloodDecodePositions(int spacing, int dimensions, int offset, int marker_size);
+	FloodDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
 
 	size_t size() const;
 	void reset();
@@ -50,5 +50,6 @@ protected:
 	std::vector<decode_instructions> _instructions;
 	CellPositions::positions_list _positions;
 	AdjacentCellFinder _cellFinder;
+	int _topWidth;
 };
 

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -9,8 +9,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 2;
 		static constexpr unsigned ecc_bytes = 40;
 		static constexpr unsigned ecc_block_size = 216;
-		static constexpr int image_size_x = 988;
-		static constexpr int image_size_y = image_size_x;
+		static constexpr unsigned image_size_x = 988;
+		static constexpr unsigned image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 5;
 		static constexpr unsigned cell_spacing_x = cell_size+1;
@@ -28,8 +28,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 2;
 		static constexpr unsigned ecc_bytes = 35;
 		static constexpr unsigned ecc_block_size = 182;
-		static constexpr int image_size_x = 958;
-		static constexpr int image_size_y = image_size_x;
+		static constexpr unsigned image_size_x = 958;
+		static constexpr unsigned image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 5;
 		static constexpr unsigned cell_spacing_x = cell_size;
@@ -47,8 +47,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 4;
 		static constexpr unsigned ecc_bytes = 30;
 		static constexpr unsigned ecc_block_size = 155;
-		static constexpr int image_size_x = 1024;
-		static constexpr int image_size_y = image_size_x;
+		static constexpr unsigned image_size_x = 1024;
+		static constexpr unsigned image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 8;
 		static constexpr unsigned cell_spacing_x = cell_size+1;
@@ -56,6 +56,25 @@ namespace cimbar
 		static constexpr unsigned cell_offset = 8;
 		static constexpr unsigned cells_per_col_x = 112;
 		static constexpr unsigned cells_per_col_y = cells_per_col_x;
+
+		static constexpr int fountain_chunks_per_frame = 2;
+	};
+
+	struct Conf8x8_mini
+	{
+		static constexpr unsigned color_bits = 2;
+		static constexpr unsigned symbol_bits = 4;
+		static constexpr unsigned ecc_bytes = 35;
+		static constexpr unsigned ecc_block_size = 174;
+		static constexpr unsigned image_size_x = 1285;
+		static constexpr unsigned image_size_y = 736;
+
+		static constexpr unsigned cell_size = 8;
+		static constexpr unsigned cell_spacing_x = cell_size+1;
+		static constexpr unsigned cell_spacing_y = cell_size+1;
+		static constexpr unsigned cell_offset = 9;
+		static constexpr unsigned cells_per_col_x = 141;
+		static constexpr unsigned cells_per_col_y = 80;
 
 		static constexpr int fountain_chunks_per_frame = 2;
 	};

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -17,6 +17,8 @@ namespace cimbar
 		static constexpr unsigned cell_offset = 9;
 		static constexpr unsigned cells_per_col_x = 162;
 		static constexpr unsigned cells_per_col_y = cells_per_col_x;
+
+		static constexpr int fountain_chunks_per_frame = 3;
 	};
 
 	struct Conf5x5d
@@ -33,6 +35,8 @@ namespace cimbar
 		static constexpr unsigned cell_offset = 9;
 		static constexpr unsigned cells_per_col_x = 188;
 		static constexpr unsigned cells_per_col_y = 157;
+
+		static constexpr int fountain_chunks_per_frame = 4;
 	};
 
 	struct Conf8x8
@@ -49,5 +53,7 @@ namespace cimbar
 		static constexpr unsigned cell_offset = 8;
 		static constexpr unsigned cells_per_col_x = 112;
 		static constexpr unsigned cells_per_col_y = cells_per_col_x;
+
+		static constexpr int fountain_chunks_per_frame = 2;
 	};
 }

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -12,8 +12,11 @@ namespace cimbar
 		static constexpr int image_size = 988;
 
 		static constexpr unsigned cell_size = 5;
+		static constexpr unsigned cell_spacing_x = 6;
+		static constexpr unsigned cell_spacing_y = 6;
 		static constexpr unsigned cell_offset = 9;
-		static constexpr unsigned cells_per_col = 162;
+		static constexpr unsigned cells_per_col_x = 162;
+		static constexpr unsigned cells_per_col_y = 162;
 	};
 
 	struct Conf8x8

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -9,7 +9,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 2;
 		static constexpr unsigned ecc_bytes = 40;
 		static constexpr unsigned ecc_block_size = 216;
-		static constexpr int image_size = 988;
+		static constexpr int image_size_x = 988;
+		static constexpr int image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 5;
 		static constexpr unsigned cell_spacing_x = cell_size+1;
@@ -27,7 +28,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 2;
 		static constexpr unsigned ecc_bytes = 35;
 		static constexpr unsigned ecc_block_size = 182;
-		static constexpr int image_size = 958;
+		static constexpr int image_size_x = 958;
+		static constexpr int image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 5;
 		static constexpr unsigned cell_spacing_x = cell_size;
@@ -45,7 +47,8 @@ namespace cimbar
 		static constexpr unsigned symbol_bits = 4;
 		static constexpr unsigned ecc_bytes = 30;
 		static constexpr unsigned ecc_block_size = 155;
-		static constexpr int image_size = 1024;
+		static constexpr int image_size_x = 1024;
+		static constexpr int image_size_y = image_size_x;
 
 		static constexpr unsigned cell_size = 8;
 		static constexpr unsigned cell_spacing_x = cell_size+1;

--- a/src/lib/cimb_translator/GridConf.h
+++ b/src/lib/cimb_translator/GridConf.h
@@ -12,11 +12,27 @@ namespace cimbar
 		static constexpr int image_size = 988;
 
 		static constexpr unsigned cell_size = 5;
-		static constexpr unsigned cell_spacing_x = 6;
-		static constexpr unsigned cell_spacing_y = 6;
+		static constexpr unsigned cell_spacing_x = cell_size+1;
+		static constexpr unsigned cell_spacing_y = cell_size+1;
 		static constexpr unsigned cell_offset = 9;
 		static constexpr unsigned cells_per_col_x = 162;
-		static constexpr unsigned cells_per_col_y = 162;
+		static constexpr unsigned cells_per_col_y = cells_per_col_x;
+	};
+
+	struct Conf5x5d
+	{
+		static constexpr unsigned color_bits = 2;
+		static constexpr unsigned symbol_bits = 2;
+		static constexpr unsigned ecc_bytes = 35;
+		static constexpr unsigned ecc_block_size = 182;
+		static constexpr int image_size = 958;
+
+		static constexpr unsigned cell_size = 5;
+		static constexpr unsigned cell_spacing_x = cell_size;
+		static constexpr unsigned cell_spacing_y = cell_size+1;
+		static constexpr unsigned cell_offset = 9;
+		static constexpr unsigned cells_per_col_x = 188;
+		static constexpr unsigned cells_per_col_y = 157;
 	};
 
 	struct Conf8x8
@@ -28,7 +44,10 @@ namespace cimbar
 		static constexpr int image_size = 1024;
 
 		static constexpr unsigned cell_size = 8;
+		static constexpr unsigned cell_spacing_x = cell_size+1;
+		static constexpr unsigned cell_spacing_y = cell_size+1;
 		static constexpr unsigned cell_offset = 8;
-		static constexpr unsigned cells_per_col = 112;
+		static constexpr unsigned cells_per_col_x = 112;
+		static constexpr unsigned cells_per_col_y = cells_per_col_x;
 	};
 }

--- a/src/lib/cimb_translator/LinearDecodePositions.h
+++ b/src/lib/cimb_translator/LinearDecodePositions.h
@@ -11,7 +11,7 @@ public:
 	using iter = std::tuple<unsigned, CellPositions::coordinate, CellDrift>;
 
 public:
-	LinearDecodePositions(int spacing, int dimensions, int offset, int marker_size);
+	LinearDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
 
 	size_t count() const;
 	void reset();
@@ -26,9 +26,9 @@ protected:
 	CellDrift _drift;
 };
 
-inline LinearDecodePositions::LinearDecodePositions(int spacing, int dimensions, int offset, int marker_size)
-    : _positions(CellPositions::compute(spacing, dimensions, offset, marker_size, 0))
-    , _drift()
+inline LinearDecodePositions::LinearDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
+	: _positions(CellPositions::compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, 0))
+	, _drift()
 {
 	reset();
 }

--- a/src/lib/cimb_translator/LinearDecodePositions.h
+++ b/src/lib/cimb_translator/LinearDecodePositions.h
@@ -11,7 +11,7 @@ public:
 	using iter = std::tuple<unsigned, CellPositions::coordinate, CellDrift>;
 
 public:
-	LinearDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y);
+	LinearDecodePositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size);
 
 	size_t count() const;
 	void reset();
@@ -26,8 +26,8 @@ protected:
 	CellDrift _drift;
 };
 
-inline LinearDecodePositions::LinearDecodePositions(int spacing_x, int spacing_y, int dimensions_x, int dimensions_y, int offset, int marker_size_x, int marker_size_y)
-	: _positions(CellPositions::compute(spacing_x, spacing_y, dimensions_x, dimensions_y, offset, marker_size_x, marker_size_y, 0))
+inline LinearDecodePositions::LinearDecodePositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size)
+	: _positions(CellPositions::compute(spacing, dimensions, offset, marker_size, 0))
 	, _drift()
 {
 	reset();

--- a/src/lib/cimb_translator/test/AdjacentCellFinderTest.cpp
+++ b/src/lib/cimb_translator/test/AdjacentCellFinderTest.cpp
@@ -12,8 +12,8 @@
 TEST_CASE( "AdjacentCellFinderTest/testFirstSection", "[unit]" )
 {
 	// there are 600 cells in the first section
-	CellPositions::positions_list positions = CellPositions::compute(9, 112, 8, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 6);
+	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
+	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
 
 	// top row
 	assertEquals( "1 -1 100 -1", turbo::str::join(finder.find(0)) );
@@ -29,8 +29,8 @@ TEST_CASE( "AdjacentCellFinderTest/testFirstSection", "[unit]" )
 TEST_CASE( "AdjacentCellFinderTest/testMiddle", "[unit]" )
 {
 	// 11200 cells in the middle
-	CellPositions::positions_list positions = CellPositions::compute(9, 112, 8, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 6);
+	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
+	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
 
 	// top row of "middle"
 	assertEquals( "601 -1 712 -1", turbo::str::join(finder.find(600)) );
@@ -50,8 +50,8 @@ TEST_CASE( "AdjacentCellFinderTest/testMiddle", "[unit]" )
 TEST_CASE( "AdjacentCellFinderTest/testLastSection", "[unit]" )
 {
 	// 600 cells in the last section
-	CellPositions::positions_list positions = CellPositions::compute(9, 112, 8, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 6);
+	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
+	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
 
 	// bottom row of grid
 	assertEquals( "12301 -1 -1 12200", turbo::str::join(finder.find(12300)) );

--- a/src/lib/cimb_translator/test/AdjacentCellFinderTest.cpp
+++ b/src/lib/cimb_translator/test/AdjacentCellFinderTest.cpp
@@ -12,8 +12,8 @@
 TEST_CASE( "AdjacentCellFinderTest/testFirstSection", "[unit]" )
 {
 	// there are 600 cells in the first section
-	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
+	CellPositions::positions_list positions = CellPositions::compute(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6}, 0);
+	AdjacentCellFinder finder(positions, cimbar::vec_xy{112, 112}, cimbar::vec_xy{6, 6});
 
 	// top row
 	assertEquals( "1 -1 100 -1", turbo::str::join(finder.find(0)) );
@@ -29,8 +29,8 @@ TEST_CASE( "AdjacentCellFinderTest/testFirstSection", "[unit]" )
 TEST_CASE( "AdjacentCellFinderTest/testMiddle", "[unit]" )
 {
 	// 11200 cells in the middle
-	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
+	CellPositions::positions_list positions = CellPositions::compute(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6}, 0);
+	AdjacentCellFinder finder(positions, cimbar::vec_xy{112, 112}, cimbar::vec_xy{6, 6});
 
 	// top row of "middle"
 	assertEquals( "601 -1 712 -1", turbo::str::join(finder.find(600)) );
@@ -50,8 +50,8 @@ TEST_CASE( "AdjacentCellFinderTest/testMiddle", "[unit]" )
 TEST_CASE( "AdjacentCellFinderTest/testLastSection", "[unit]" )
 {
 	// 600 cells in the last section
-	CellPositions::positions_list positions = CellPositions::compute(9, 9, 112, 112, 8, 6, 6, 0);
-	AdjacentCellFinder finder(positions, 112, 112, 6, 6);
+	CellPositions::positions_list positions = CellPositions::compute(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6}, 0);
+	AdjacentCellFinder finder(positions, cimbar::vec_xy{112, 112}, cimbar::vec_xy{6, 6});
 
 	// bottom row of grid
 	assertEquals( "12301 -1 -1 12200", turbo::str::join(finder.find(12300)) );

--- a/src/lib/cimb_translator/test/CellPositionsTest.cpp
+++ b/src/lib/cimb_translator/test/CellPositionsTest.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE( "CellPositionsTest/testSimple", "[unit]" )
 {
-	CellPositions cells(9, 9, 112, 112, 8, 6, 6);
+	CellPositions cells(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6});
 
 	// test first coordinate. We'll just count the rest.
 	assertFalse( cells.done() );

--- a/src/lib/cimb_translator/test/CellPositionsTest.cpp
+++ b/src/lib/cimb_translator/test/CellPositionsTest.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE( "CellPositionsTest/testSimple", "[unit]" )
 {
-	CellPositions cells(9, 112, 8, 6);
+	CellPositions cells(9, 9, 112, 112, 8, 6, 6);
 
 	// test first coordinate. We'll just count the rest.
 	assertFalse( cells.done() );

--- a/src/lib/cimb_translator/test/CellTest.cpp
+++ b/src/lib/cimb_translator/test/CellTest.cpp
@@ -131,7 +131,7 @@ TEST_CASE( "CellTest/testRgbCellOffsets.Asymmetric.Contiguous", "[unit]" )
 	}
 }
 
-TEST_CASE( "CellTest/testRgbCellOffsets.WideCanvas", "[unit]" )
+/*TEST_CASE( "CellTest/testRgbCellOffsets.WideCanvas", "[unit]" )
 {
 	cv::Mat img = TestCimbar::loadSample("bm/ecc35.png");
 
@@ -156,4 +156,4 @@ TEST_CASE( "CellTest/testRgbCellOffsets.WideCanvas", "[unit]" )
 		assertAlmostEquals( expectedColor[2], (int)b );
 		assertEquals( 148, (int)b );
 	}
-}
+}*/

--- a/src/lib/cimb_translator/test/CellTest.cpp
+++ b/src/lib/cimb_translator/test/CellTest.cpp
@@ -108,21 +108,52 @@ TEST_CASE( "CellTest/testRgbCellOffsets.Asymmetric.Contiguous", "[unit]" )
 {
 	cv::Mat img = TestCimbar::loadSample("6bit/4color_ecc30_fountain_0.png");
 
-	cv::Rect crop(125, 8, 4, 6);
+	cv::Rect crop(126, 9, 6, 6);
 	cv::Mat cell = img(crop);
+	cv::Scalar expectedColor = cv::mean(cell);
 
-	auto [r, g, b] = Cell(img, 125, 8, 4, 6).mean_rgb();
+	auto [r, g, b] = Cell(img, 126, 9, 6, 6).mean_rgb();
 
 	DYNAMIC_SECTION( "r" )
 	{
-		assertEquals( 191, (int)r );
+		assertAlmostEquals( expectedColor[0], (int)r );
+		assertEquals( 198, (int)r );
 	}
 	DYNAMIC_SECTION( "g" )
 	{
-		assertEquals( 191, (int)g );
+		assertAlmostEquals( expectedColor[1], (int)g );
+		assertEquals( 198, (int)g );
 	}
 	DYNAMIC_SECTION( "b" )
 	{
+		assertAlmostEquals( expectedColor[2], (int)b );
 		assertEquals( 0, (int)b );
+	}
+}
+
+TEST_CASE( "CellTest/testRgbCellOffsets.WideCanvas", "[unit]" )
+{
+	cv::Mat img = TestCimbar::loadSample("bm/ecc35.png");
+
+	cv::Rect crop(127, 10, 6, 6);
+	cv::Mat cell = img(crop);
+	cv::Scalar expectedColor = cv::mean(cell);
+
+	auto [r, g, b] = Cell(img, 127, 10, 6, 6).mean_rgb();
+
+	DYNAMIC_SECTION( "r" )
+	{
+		assertAlmostEquals( expectedColor[0], (int)r );
+		assertEquals( 148, (int)r );
+	}
+	DYNAMIC_SECTION( "g" )
+	{
+		assertAlmostEquals( expectedColor[1], (int)g );
+		assertEquals( 0, (int)g );
+	}
+	DYNAMIC_SECTION( "b" )
+	{
+		assertAlmostEquals( expectedColor[2], (int)b );
+		assertEquals( 148, (int)b );
 	}
 }

--- a/src/lib/cimb_translator/test/CimbWriterTest.cpp
+++ b/src/lib/cimb_translator/test/CimbWriterTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE( "CimbWriterTest/testSimple", "[unit]" )
 
 TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
 {
-	CimbWriter cw(4, 2, true, 1, 1040, 1040);
+	CimbWriter cw(4, 2, true, 1, {1040, 1040});
 
 	while (1)
 	{
@@ -43,7 +43,7 @@ TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
 
 TEST_CASE( "CimbWriterTest/testCustomSize.2", "[unit]" )
 {
-	CimbWriter cw(4, 2, true, 1, 1040, 1080);
+	CimbWriter cw(4, 2, true, 1, {1040, 1080});
 
 	while (1)
 	{

--- a/src/lib/cimb_translator/test/CimbWriterTest.cpp
+++ b/src/lib/cimb_translator/test/CimbWriterTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE( "CimbWriterTest/testSimple", "[unit]" )
 
 TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
 {
-	CimbWriter cw(4, 2, true, 1, 1040);
+	CimbWriter cw(4, 2, true, 1, 1040, 1040);
 
 	while (1)
 	{
@@ -39,4 +39,20 @@ TEST_CASE( "CimbWriterTest/testCustomSize", "[unit]" )
 	assertEquals(1040, img.cols);
 	assertEquals(1040, img.rows);
 	assertEquals( 0xab00ab02af0abfab, image_hash::average_hash(img) );
+}
+
+TEST_CASE( "CimbWriterTest/testCustomSize.2", "[unit]" )
+{
+	CimbWriter cw(4, 2, true, 1, 1040, 1080);
+
+	while (1)
+	{
+		if (!cw.write(0))
+			break;
+	}
+
+	cv::Mat img = cw.image();
+	assertEquals(1040, img.cols);
+	assertEquals(1080, img.rows);
+	assertEquals( 0xab2a2a2a2a2a2aab, image_hash::average_hash(img) );
 }

--- a/src/lib/cimb_translator/test/FloodDecodePositionsTest.cpp
+++ b/src/lib/cimb_translator/test/FloodDecodePositionsTest.cpp
@@ -12,7 +12,7 @@ TEST_CASE( "FloodDecodePositionsTest/testSimple", "[unit]" )
 {
 	const unsigned posCount = 12400;
 
-	FloodDecodePositions cells(9, 112, 8, 6);
+	FloodDecodePositions cells(9, 9, 112, 112, 8, 6, 6);
 	std::set<unsigned> remainingPos;
 	for (unsigned i = 0; i < posCount; ++i)
 		remainingPos.insert(i);

--- a/src/lib/cimb_translator/test/FloodDecodePositionsTest.cpp
+++ b/src/lib/cimb_translator/test/FloodDecodePositionsTest.cpp
@@ -12,7 +12,7 @@ TEST_CASE( "FloodDecodePositionsTest/testSimple", "[unit]" )
 {
 	const unsigned posCount = 12400;
 
-	FloodDecodePositions cells(9, 9, 112, 112, 8, 6, 6);
+	FloodDecodePositions cells(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6});
 	std::set<unsigned> remainingPos;
 	for (unsigned i = 0; i < posCount; ++i)
 		remainingPos.insert(i);

--- a/src/lib/cimb_translator/test/InterleaveTest.cpp
+++ b/src/lib/cimb_translator/test/InterleaveTest.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "InterleaveTest/testReverse", "[unit]" )
 
 TEST_CASE( "InterleaveTest/testCellPositions", "[unit]" )
 {
-	std::vector<unsigned> indices = Interleave::interleave_reverse(CellPositions::compute_linear(9, 9, 112, 112, 8, 6, 6).size(), 155, 1);
+	std::vector<unsigned> indices = Interleave::interleave_reverse(CellPositions::compute_linear(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6}).size(), 155, 1);
 	assertEquals( 12400, indices.size() );
 	assertEquals( 0, indices[0] );
 	assertEquals( 80, indices[1] );

--- a/src/lib/cimb_translator/test/InterleaveTest.cpp
+++ b/src/lib/cimb_translator/test/InterleaveTest.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "InterleaveTest/testReverse", "[unit]" )
 
 TEST_CASE( "InterleaveTest/testCellPositions", "[unit]" )
 {
-	std::vector<unsigned> indices = Interleave::interleave_reverse(CellPositions::compute_linear(9, 112, 8, 6).size(), 155, 1);
+	std::vector<unsigned> indices = Interleave::interleave_reverse(CellPositions::compute_linear(9, 9, 112, 112, 8, 6, 6).size(), 155, 1);
 	assertEquals( 12400, indices.size() );
 	assertEquals( 0, indices[0] );
 	assertEquals( 80, indices[1] );

--- a/src/lib/cimb_translator/test/LinearDecodePositionsTest.cpp
+++ b/src/lib/cimb_translator/test/LinearDecodePositionsTest.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE( "LinearDecodePositionsTest/testSimple", "[unit]" )
 {
-	LinearDecodePositions cells(9, 112, 8, 6);
+	LinearDecodePositions cells(9, 9, 112, 112, 8, 6, 6);
 
 	// test first coordinate. We'll just count the rest.
 	assertFalse( cells.done() );

--- a/src/lib/cimb_translator/test/LinearDecodePositionsTest.cpp
+++ b/src/lib/cimb_translator/test/LinearDecodePositionsTest.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE( "LinearDecodePositionsTest/testSimple", "[unit]" )
 {
-	LinearDecodePositions cells(9, 9, 112, 112, 8, 6, 6);
+	LinearDecodePositions cells(cimbar::vec_xy{9, 9}, cimbar::vec_xy{112, 112}, 8, cimbar::vec_xy{6, 6});
 
 	// test first coordinate. We'll just count the rest.
 	assertFalse( cells.done() );

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -85,7 +85,7 @@ int next_frame()
 		enc.set_legacy_mode();
 
 	enc.set_encode_id(_encodeId);
-	_next = enc.encode_next(*_fes, {(int)_window->width(), (int)_window->height()});
+	_next = enc.encode_next(*_fes, cimbar::vec_xy{_window->width(), _window->height()});
 	return ++_frameCount;
 }
 

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -86,7 +86,7 @@ int next_frame()
 		enc.set_legacy_mode();
 
 	enc.set_encode_id(_encodeId);
-	_next = enc.encode_next(*_fes, _window->width());
+	_next = enc.encode_next(*_fes, _window->width(), _window->height());
 	return ++_frameCount;
 }
 

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -86,7 +86,7 @@ int next_frame()
 		enc.set_legacy_mode();
 
 	enc.set_encode_id(_encodeId);
-	_next = enc.encode_next(*_fes, _window->width(), _window->height());
+	_next = enc.encode_next(*_fes, {(int)_window->width(), (int)_window->height()});
 	return ++_frameCount;
 }
 

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -46,6 +46,15 @@ int initialize_GL(int width, int height)
 	return 1;
 }
 
+bool auto_scale_window()
+{
+	if (!_window or !_window->is_good())
+		return false;
+
+	_window->auto_scale_to_window();
+	return true;
+}
+
 // render() and next_frame() could be put in the same function,
 // but it seems cleaner to split them.
 // in any case, we're concerned with frame pacing (some encodes take longer than others)

--- a/src/lib/cimbar_js/cimbar_js.h
+++ b/src/lib/cimbar_js/cimbar_js.h
@@ -7,6 +7,7 @@ extern "C" {
 #endif
 
 int initialize_GL(int width, int height);
+bool auto_scale_window();
 int render();
 int next_frame();
 int encode(unsigned char* buffer, unsigned size, int encode_id);  // encode_id == -1 -> auto-increment

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -15,8 +15,8 @@ public:
 	using SimpleEncoder::SimpleEncoder;
 
 	unsigned encode(const std::string& filename, std::string output_prefix);
-	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=16, double redundancy=1.2, int canvas_size=0);
-	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=16, double redundancy=4.0, int canvas_size=0);
+	unsigned encode_fountain(const std::string& filename, std::string output_prefix, int compression_level=16, double redundancy=1.2);
+	unsigned encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level=16, double redundancy=4.0);
 };
 
 inline unsigned Encoder::encode(const std::string& filename, std::string output_prefix)
@@ -39,7 +39,7 @@ inline unsigned Encoder::encode(const std::string& filename, std::string output_
 	return i;
 }
 
-inline unsigned Encoder::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy, int canvas_size)
+inline unsigned Encoder::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy)
 {
 	std::ifstream infile(filename);
 	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, compression_level);
@@ -57,7 +57,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	unsigned i = 0;
 	while (i < requiredFrames)
 	{
-		auto frame = encode_next(*fes, canvas_size);
+		auto frame = encode_next(*fes);
 		if (!frame)
 			break;
 
@@ -68,7 +68,7 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, const std:
 	return i;
 }
 
-inline unsigned Encoder::encode_fountain(const std::string& filename, std::string output_prefix, int compression_level, double redundancy, int canvas_size)
+inline unsigned Encoder::encode_fountain(const std::string& filename, std::string output_prefix, int compression_level, double redundancy)
 {
 	std::function<bool(const cv::Mat&, unsigned)> fun = [output_prefix] (const cv::Mat& frame, unsigned i) {
 		std::string output = fmt::format("{}_{}.png", output_prefix, i);
@@ -76,5 +76,5 @@ inline unsigned Encoder::encode_fountain(const std::string& filename, std::strin
 		cv::cvtColor(frame, bgr, cv::COLOR_RGB2BGR);
 		return cv::imwrite(output, bgr);
 	};
-	return encode_fountain(filename, fun, compression_level, redundancy, canvas_size);
+	return encode_fountain(filename, fun, compression_level, redundancy);
 }

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -21,14 +21,14 @@ public:
 	void set_encode_id(uint8_t encode_id); // [0-127] -- the high bit is ignored.
 
 	template <typename STREAM>
-	std::optional<cv::Mat> encode_next(STREAM& stream, int canvas_size=0);
+	std::optional<cv::Mat> encode_next(STREAM& stream, int canvas_width=0, int canvas_height=0);
 
 	template <typename STREAM>
 	fountain_encoder_stream::ptr create_fountain_encoder(STREAM& stream, int compression_level=6);
 
 protected:
 	template <typename STREAM>
-	std::optional<cv::Mat> encode_next_coupled(STREAM& stream, int canvas_size=0);
+	std::optional<cv::Mat> encode_next_coupled(STREAM& stream, int canvas_width=0, int canvas_height=0);
 
 protected:
 	unsigned _eccBytes;
@@ -64,16 +64,16 @@ inline void SimpleEncoder::set_encode_id(uint8_t encode_id)
 }
 
 template <typename STREAM>
-inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int canvas_size)
+inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int canvas_width, int canvas_height)
 {
 	if (_coupled)
-		return encode_next_coupled(stream, canvas_size);
+		return encode_next_coupled(stream, canvas_width, canvas_height);
 
 	if (!stream.good())
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_size);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_width, canvas_height);
 
 	unsigned numCells = writer.num_cells();
 	bitbuffer bb(cimbar::Config::capacity(bits_per_op));
@@ -127,7 +127,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int can
 }
 
 template <typename STREAM>
-inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream, int canvas_size)
+inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream, int canvas_width, int canvas_height)
 {
 	// the old way. Symbol and color bits are mixed together, limiting the color correction possibilities
 	// but potentially allowing a lack of errors in one channel to correct errors in the other.
@@ -138,7 +138,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream,
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_size);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_width, canvas_height);
 
 	reed_solomon_stream rss(stream, _eccBytes, _eccBlockSize);
 	bitreader br;

--- a/src/lib/encoder/SimpleEncoder.h
+++ b/src/lib/encoder/SimpleEncoder.h
@@ -73,7 +73,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next(STREAM& stream, int can
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_width, canvas_height);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, {canvas_width, canvas_height});
 
 	unsigned numCells = writer.num_cells();
 	bitbuffer bb(cimbar::Config::capacity(bits_per_op));
@@ -138,7 +138,7 @@ inline std::optional<cv::Mat> SimpleEncoder::encode_next_coupled(STREAM& stream,
 		return std::nullopt;
 
 	unsigned bits_per_op = _bitsPerColor + _bitsPerSymbol;
-	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, canvas_width, canvas_height);
+	CimbWriter writer(_bitsPerSymbol, _bitsPerColor, _dark, _colorMode, {canvas_width, canvas_height});
 
 	reed_solomon_stream rss(stream, _eccBytes, _eccBlockSize);
 	bitreader br;

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -131,12 +131,12 @@ TEST_CASE( "EncoderTest/testFountain.Size", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	Encoder enc(30, 4, 2);
-	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6, 1080) );
+	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6) );
 
-	uint64_t hash = 0xbdc232c714226fe6;
+	uint64_t hash = 0xb36b65402eec434e;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
-	assertEquals( 1080, img.rows );
-	assertEquals( 1080, img.cols );
+	assertEquals( 1024, img.rows );
+	assertEquals( 1024, img.cols );
 	assertEquals( hash, image_hash::average_hash(img) );
 }

--- a/src/lib/extractor/Corners.h
+++ b/src/lib/extractor/Corners.h
@@ -10,15 +10,15 @@ class Corners
 {
 public:
 	Corners(const std::vector<Anchor>& anchors)
-	    : Corners(anchors[0].center(), anchors[1].center(), anchors[2].center(), anchors[3].center())
+		: Corners(anchors[0].center(), anchors[1].center(), anchors[2].center(), anchors[3].center())
 	{
 	}
 
 	Corners(point<int> top_left, point<int> top_right, point<int> bottom_left, point<int> bottom_right)
-	    : _top_left(top_left)
-	    , _top_right(top_right)
-	    , _bottom_left(bottom_left)
-	    , _bottom_right(bottom_right)
+		: _top_left(top_left)
+		, _top_right(top_right)
+		, _bottom_left(bottom_left)
+		, _bottom_right(bottom_right)
 	{
 	}
 
@@ -52,21 +52,21 @@ public:
 		return points;
 	}
 
-	bool is_granular_scale(unsigned min_size) const
+	bool is_granular_scale(unsigned min_width, unsigned min_height) const
 	{
 		// if any of our edges are < min_size, return false -- this means we'll be upscaling when we run a deskew.
 		return (
-		        check_scaling(_top_left, _top_right, min_size) and
-		        check_scaling(_top_right, _bottom_right, min_size) and
-		        check_scaling(_bottom_right, _bottom_left, min_size) and
-		        check_scaling(_bottom_left, _top_left, min_size)
+				check_scaling(_top_left, _top_right, min_width, min_height) and
+				check_scaling(_top_right, _bottom_right, min_width, min_height) and
+				check_scaling(_bottom_right, _bottom_left, min_width, min_height) and
+				check_scaling(_bottom_left, _top_left, min_width, min_height)
 		);
 	}
 
 protected:
-	bool check_scaling(const point<int>& a, const point<int>& b, unsigned min_size) const
+	bool check_scaling(const point<int>& a, const point<int>& b, unsigned min_width, unsigned min_height) const
 	{
-		return abs(a.x() - b.x()) > min_size or abs(a.y() - b.y()) > min_size;
+		return abs(a.x() - b.x()) > min_width or abs(a.y() - b.y()) > min_height;
 	}
 
 protected:

--- a/src/lib/extractor/Corners.h
+++ b/src/lib/extractor/Corners.h
@@ -3,8 +3,8 @@
 
 #include "Anchor.h"
 #include "Point.h"
+#include "util/vec_xy.h"
 #include <opencv2/opencv.hpp>
-#include <tuple>
 
 class Corners
 {
@@ -52,21 +52,21 @@ public:
 		return points;
 	}
 
-	bool is_granular_scale(unsigned min_width, unsigned min_height) const
+	bool is_granular_scale(cimbar::vec_xy min_size) const
 	{
 		// if any of our edges are < min_size, return false -- this means we'll be upscaling when we run a deskew.
 		return (
-				check_scaling(_top_left, _top_right, min_width, min_height) and
-				check_scaling(_top_right, _bottom_right, min_width, min_height) and
-				check_scaling(_bottom_right, _bottom_left, min_width, min_height) and
-				check_scaling(_bottom_left, _top_left, min_width, min_height)
+				check_scaling(_top_left, _top_right, min_size) and
+				check_scaling(_top_right, _bottom_right, min_size) and
+				check_scaling(_bottom_right, _bottom_left, min_size) and
+				check_scaling(_bottom_left, _top_left, min_size)
 		);
 	}
 
 protected:
-	bool check_scaling(const point<int>& a, const point<int>& b, unsigned min_width, unsigned min_height) const
+	bool check_scaling(const point<int>& a, const point<int>& b, cimbar::vec_xy min_size) const
 	{
-		return abs(a.x() - b.x()) > min_width or abs(a.y() - b.y()) > min_height;
+		return abs(a.x() - b.x()) > min_size.width() or abs(a.y() - b.y()) > min_size.height();
 	}
 
 protected:

--- a/src/lib/extractor/Deskewer.cpp
+++ b/src/lib/extractor/Deskewer.cpp
@@ -4,15 +4,21 @@
 
 #include <iostream>
 
-Deskewer::Deskewer(unsigned image_size, unsigned anchor_size)
-	: _imageSize(image_size? image_size : cimbar::Config::image_size())
+Deskewer::Deskewer(unsigned image_width, unsigned image_height, unsigned anchor_size)
+	: _imageWidth(image_width? image_width : cimbar::Config::image_size_x())
+	, _imageHeight(image_height? image_height : cimbar::Config::image_size_y())
 	, _anchorSize(anchor_size? anchor_size : cimbar::Config::anchor_size())
 {
 }
 
-unsigned Deskewer::image_size() const
+unsigned Deskewer::image_width() const
 {
-	return _imageSize;
+	return _imageWidth;
+}
+
+unsigned Deskewer::image_height() const
+{
+	return _imageHeight;
 }
 
 cv::Mat Deskewer::deskew(std::string img, const Corners& corners)

--- a/src/lib/extractor/Deskewer.cpp
+++ b/src/lib/extractor/Deskewer.cpp
@@ -4,21 +4,12 @@
 
 #include <iostream>
 
-Deskewer::Deskewer(unsigned image_width, unsigned image_height, unsigned anchor_size)
-	: _imageWidth(image_width? image_width : cimbar::Config::image_size_x())
-	, _imageHeight(image_height? image_height : cimbar::Config::image_size_y())
+Deskewer::Deskewer(cimbar::vec_xy image_size, unsigned anchor_size)
+	: _imageSize({
+		image_size.width()? image_size.width() : cimbar::Config::image_size_x(),
+		image_size.height()? image_size.height() : cimbar::Config::image_size_y()})
 	, _anchorSize(anchor_size? anchor_size : cimbar::Config::anchor_size())
 {
-}
-
-unsigned Deskewer::image_width() const
-{
-	return _imageWidth;
-}
-
-unsigned Deskewer::image_height() const
-{
-	return _imageHeight;
 }
 
 cv::Mat Deskewer::deskew(std::string img, const Corners& corners)

--- a/src/lib/extractor/Deskewer.h
+++ b/src/lib/extractor/Deskewer.h
@@ -3,6 +3,7 @@
 
 #include "Corners.h"
 
+#include "util/vec_xy.h"
 #include <opencv2/opencv.hpp>
 
 #include <string>
@@ -11,9 +12,7 @@
 class Deskewer
 {
 public:
-	Deskewer(unsigned image_width=0, unsigned image_height=0, unsigned anchor_size=0);
-	unsigned image_width() const;
-	unsigned image_height() const;
+	Deskewer(cimbar::vec_xy image_size={}, unsigned anchor_size=0);
 
 	template <typename MAT>
 	MAT deskew(const MAT& img, const Corners& corners);
@@ -22,8 +21,7 @@ public:
 	bool save(const cv::Mat& img, std::string path);
 
 protected:
-	int _imageWidth;
-	int _imageHeight;
+	cimbar::vec_xy _imageSize;
 	int _anchorSize;
 };
 
@@ -32,11 +30,11 @@ inline MAT Deskewer::deskew(const MAT& img, const Corners& corners)
 {
 	std::vector<cv::Point2f> outputPoints;
 	outputPoints.push_back(cv::Point2f(_anchorSize, _anchorSize));
-	outputPoints.push_back(cv::Point2f(_imageWidth - _anchorSize, _anchorSize));
-	outputPoints.push_back(cv::Point2f(_anchorSize, _imageHeight - _anchorSize));
-	outputPoints.push_back(cv::Point2f(_imageWidth - _anchorSize, _imageHeight - _anchorSize));
+	outputPoints.push_back(cv::Point2f(_imageSize.width() - _anchorSize, _anchorSize));
+	outputPoints.push_back(cv::Point2f(_anchorSize, _imageSize.height() - _anchorSize));
+	outputPoints.push_back(cv::Point2f(_imageSize.width() - _anchorSize, _imageSize.height() - _anchorSize));
 
-	MAT output(_imageHeight, _imageWidth, img.type());
+	MAT output(_imageSize.height(), _imageSize.width(), img.type());
 	cv::Mat transform = cv::getPerspectiveTransform(corners.all(), outputPoints);
 
 	cv::warpPerspective(img, output, transform, output.size(), cv::INTER_LINEAR);

--- a/src/lib/extractor/Deskewer.h
+++ b/src/lib/extractor/Deskewer.h
@@ -11,8 +11,9 @@
 class Deskewer
 {
 public:
-	Deskewer(unsigned image_size=0, unsigned anchor_size=0);
-	unsigned image_size() const;
+	Deskewer(unsigned image_width=0, unsigned image_height=0, unsigned anchor_size=0);
+	unsigned image_width() const;
+	unsigned image_height() const;
 
 	template <typename MAT>
 	MAT deskew(const MAT& img, const Corners& corners);
@@ -21,7 +22,8 @@ public:
 	bool save(const cv::Mat& img, std::string path);
 
 protected:
-	int _imageSize;
+	int _imageWidth;
+	int _imageHeight;
 	int _anchorSize;
 };
 
@@ -30,11 +32,11 @@ inline MAT Deskewer::deskew(const MAT& img, const Corners& corners)
 {
 	std::vector<cv::Point2f> outputPoints;
 	outputPoints.push_back(cv::Point2f(_anchorSize, _anchorSize));
-	outputPoints.push_back(cv::Point2f(_imageSize - _anchorSize, _anchorSize));
-	outputPoints.push_back(cv::Point2f(_anchorSize, _imageSize - _anchorSize));
-	outputPoints.push_back(cv::Point2f(_imageSize - _anchorSize, _imageSize - _anchorSize));
+	outputPoints.push_back(cv::Point2f(_imageWidth - _anchorSize, _anchorSize));
+	outputPoints.push_back(cv::Point2f(_anchorSize, _imageHeight - _anchorSize));
+	outputPoints.push_back(cv::Point2f(_imageWidth - _anchorSize, _imageHeight - _anchorSize));
 
-	MAT output(_imageSize, _imageSize, img.type());
+	MAT output(_imageHeight, _imageWidth, img.type());
 	cv::Mat transform = cv::getPerspectiveTransform(corners.all(), outputPoints);
 
 	cv::warpPerspective(img, output, transform, output.size(), cv::INTER_LINEAR);

--- a/src/lib/extractor/Extractor.cpp
+++ b/src/lib/extractor/Extractor.cpp
@@ -7,9 +7,10 @@
 #include <vector>
 using std::string;
 
-Extractor::Extractor(unsigned image_width, unsigned image_height, unsigned anchor_size)
-	: _imageWidth(image_width? image_width : cimbar::Config::image_size_x())
-	, _imageHeight(image_height? image_height : cimbar::Config::image_size_y())
+Extractor::Extractor(cimbar::vec_xy image_size, unsigned anchor_size)
+	: _imageSize({
+		image_size.width()? image_size.width() : cimbar::Config::image_size_x(),
+		image_size.height()? image_size.height() : cimbar::Config::image_size_y()})
 	, _anchorSize(anchor_size? anchor_size : cimbar::Config::anchor_size())
 {
 }
@@ -22,10 +23,10 @@ int Extractor::extract(const cv::Mat& img, cv::Mat& out)
 		return FAILURE;
 
 	Corners corners(points);
-	Deskewer de(_imageWidth, _imageHeight, _anchorSize);
+	Deskewer de(_imageSize, _anchorSize);
 	out = de.deskew(img, corners);
 
-	if ( !corners.is_granular_scale(de.image_width(), de.image_height()) )
+	if ( !corners.is_granular_scale(_imageSize) )
 		return NEEDS_SHARPEN;
 	return SUCCESS;
 }
@@ -38,10 +39,10 @@ int Extractor::extract(const cv::UMat& img, cv::UMat& out)
 		return FAILURE;
 
 	Corners corners(points);
-	Deskewer de(_imageWidth, _imageHeight, _anchorSize);
+	Deskewer de(_imageSize, _anchorSize);
 	out = de.deskew(img, corners);
 
-	if ( !corners.is_granular_scale(de.image_width(), de.image_height()) )
+	if ( !corners.is_granular_scale(_imageSize) )
 		return NEEDS_SHARPEN;
 	return SUCCESS;
 }

--- a/src/lib/extractor/Extractor.cpp
+++ b/src/lib/extractor/Extractor.cpp
@@ -7,8 +7,9 @@
 #include <vector>
 using std::string;
 
-Extractor::Extractor(unsigned image_size, unsigned anchor_size)
-	: _imageSize(image_size? image_size : cimbar::Config::image_size())
+Extractor::Extractor(unsigned image_width, unsigned image_height, unsigned anchor_size)
+	: _imageWidth(image_width? image_width : cimbar::Config::image_size_x())
+	, _imageHeight(image_height? image_height : cimbar::Config::image_size_y())
 	, _anchorSize(anchor_size? anchor_size : cimbar::Config::anchor_size())
 {
 }
@@ -21,10 +22,10 @@ int Extractor::extract(const cv::Mat& img, cv::Mat& out)
 		return FAILURE;
 
 	Corners corners(points);
-	Deskewer de(_imageSize, _anchorSize);
+	Deskewer de(_imageWidth, _imageHeight, _anchorSize);
 	out = de.deskew(img, corners);
 
-	if ( !corners.is_granular_scale(de.image_size()) )
+	if ( !corners.is_granular_scale(de.image_width(), de.image_height()) )
 		return NEEDS_SHARPEN;
 	return SUCCESS;
 }
@@ -37,10 +38,10 @@ int Extractor::extract(const cv::UMat& img, cv::UMat& out)
 		return FAILURE;
 
 	Corners corners(points);
-	Deskewer de(_imageSize, _anchorSize);
+	Deskewer de(_imageWidth, _imageHeight, _anchorSize);
 	out = de.deskew(img, corners);
 
-	if ( !corners.is_granular_scale(de.image_size()) )
+	if ( !corners.is_granular_scale(de.image_width(), de.image_height()) )
 		return NEEDS_SHARPEN;
 	return SUCCESS;
 }

--- a/src/lib/extractor/Extractor.h
+++ b/src/lib/extractor/Extractor.h
@@ -12,7 +12,7 @@ public:
 	static constexpr int NEEDS_SHARPEN = 2;
 
 public:
-	Extractor(unsigned image_size=0, unsigned anchor_size=0);
+	Extractor(unsigned image_width=0, unsigned image_height=0, unsigned anchor_size=0);
 
 	int extract(const cv::Mat& img, cv::Mat& out);
 	int extract(const cv::UMat& img, cv::UMat& out);
@@ -20,6 +20,7 @@ public:
 	int extract(std::string read_path, std::string write_path);
 
 protected:
-	unsigned _imageSize;
+	unsigned _imageWidth;
+	unsigned _imageHeight;
 	unsigned _anchorSize;
 };

--- a/src/lib/extractor/Extractor.h
+++ b/src/lib/extractor/Extractor.h
@@ -1,6 +1,7 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #pragma once
 
+#include "util/vec_xy.h"
 #include <opencv2/opencv.hpp>
 #include <string>
 
@@ -12,7 +13,7 @@ public:
 	static constexpr int NEEDS_SHARPEN = 2;
 
 public:
-	Extractor(unsigned image_width=0, unsigned image_height=0, unsigned anchor_size=0);
+	Extractor(cimbar::vec_xy image_size={}, unsigned anchor_size=0);
 
 	int extract(const cv::Mat& img, cv::Mat& out);
 	int extract(const cv::UMat& img, cv::UMat& out);
@@ -20,7 +21,6 @@ public:
 	int extract(std::string read_path, std::string write_path);
 
 protected:
-	unsigned _imageWidth;
-	unsigned _imageHeight;
+	cimbar::vec_xy _imageSize;
 	unsigned _anchorSize;
 };

--- a/src/lib/extractor/test/DeskewerTest.cpp
+++ b/src/lib/extractor/test/DeskewerTest.cpp
@@ -4,14 +4,12 @@
 
 #include "Deskewer.h"
 #include "image_hash/average_hash.h"
-#include <iostream>
 #include <string>
-#include <vector>
 
 TEST_CASE( "DeskewerTest/testSimple", "[unit]" )
 {
 	Corners corners({312, 519}, {323, 2586}, {2405, 461}, {2425, 2594});
-	Deskewer de(1024, 1024, 30);
+	Deskewer de({1024, 1024}, 30);
 
 	cv::Mat actual = de.deskew(TestCimbar::getSample("6bit/4_30_f0_big.jpg"), corners);
 	assertEquals(cv::Size(1024, 1024), actual.size());

--- a/src/lib/extractor/test/DeskewerTest.cpp
+++ b/src/lib/extractor/test/DeskewerTest.cpp
@@ -11,7 +11,7 @@
 TEST_CASE( "DeskewerTest/testSimple", "[unit]" )
 {
 	Corners corners({312, 519}, {323, 2586}, {2405, 461}, {2425, 2594});
-	Deskewer de(1024, 30);
+	Deskewer de(1024, 1024, 30);
 
 	cv::Mat actual = de.deskew(TestCimbar::getSample("6bit/4_30_f0_big.jpg"), corners);
 	assertEquals(cv::Size(1024, 1024), actual.size());

--- a/src/lib/extractor/test/ExtractorTest.cpp
+++ b/src/lib/extractor/test/ExtractorTest.cpp
@@ -14,7 +14,7 @@ TEST_CASE( "ExtractorTest/testExtract", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "ex.jpg";
-	Extractor ext(1024, 30);
+	Extractor ext(1024, 1024, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f0_big.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);
@@ -27,7 +27,7 @@ TEST_CASE( "ExtractorTest/testExtractMid", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "ex.jpg";
-	Extractor ext(1024, 30);
+	Extractor ext(1024, 1024, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f2_734.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);
@@ -40,7 +40,7 @@ TEST_CASE( "ExtractorTest/testExtractUpscale", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "exup.jpg";
-	Extractor ext(1024, 30);
+	Extractor ext(1024, 1024, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f0_627.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);

--- a/src/lib/extractor/test/ExtractorTest.cpp
+++ b/src/lib/extractor/test/ExtractorTest.cpp
@@ -14,7 +14,7 @@ TEST_CASE( "ExtractorTest/testExtract", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "ex.jpg";
-	Extractor ext(1024, 1024, 30);
+	Extractor ext({1024, 1024}, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f0_big.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);
@@ -27,7 +27,7 @@ TEST_CASE( "ExtractorTest/testExtractMid", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "ex.jpg";
-	Extractor ext(1024, 1024, 30);
+	Extractor ext({1024, 1024}, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f2_734.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);
@@ -40,7 +40,7 @@ TEST_CASE( "ExtractorTest/testExtractUpscale", "[unit]" )
 	MakeTempDirectory tempdir;
 
 	std::string imgPath = tempdir.path() / "exup.jpg";
-	Extractor ext(1024, 1024, 30);
+	Extractor ext({1024, 1024}, 30);
 	ext.extract(TestCimbar::getSample("6bit/4_30_f0_627.jpg"), imgPath);
 
 	cv::Mat out = cv::imread(imgPath);

--- a/src/lib/extractor/test/UndistortTest.cpp
+++ b/src/lib/extractor/test/UndistortTest.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "UndistortTest/testUndistortAndExtract", "[unit]" )
 	Undistort<SimpleCameraCalibration> und;
 	assertTrue( und.undistort(img, out) );
 
-	Extractor ex(1024, 30);
+	Extractor ex(1024, 1024, 30);
 	assertTrue( ex.extract(out, out) );
 
 	assertEquals( 0x18f26faca7766794, image_hash::average_hash(out) );

--- a/src/lib/extractor/test/UndistortTest.cpp
+++ b/src/lib/extractor/test/UndistortTest.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "UndistortTest/testUndistortAndExtract", "[unit]" )
 	Undistort<SimpleCameraCalibration> und;
 	assertTrue( und.undistort(img, out) );
 
-	Extractor ex(1024, 1024, 30);
+	Extractor ex({1024, 1024}, 30);
 	assertTrue( ex.extract(out, out) );
 
 	assertEquals( 0x18f26faca7766794, image_hash::average_hash(out) );

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -64,6 +64,7 @@ public:
 	{
 		if (!is_good())
 			return;
+		glfwSetWindowAspectRatio(_w, _width, _height);
 		auto fun = [](GLFWwindow*, int w, int h){ glViewport(0, 0, w, h); };
 		glfwSetWindowSizeCallback(_w, fun);
 	}

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -15,7 +15,8 @@ class window_glfw
 {
 public:
 	window_glfw(unsigned width, unsigned height, std::string title)
-	    : _width(width)
+		: _width(width)
+		, _height(height)
 	{
 		if (!glfwInit())
 		{
@@ -108,6 +109,11 @@ public:
 		return _width;
 	}
 
+	unsigned height() const
+	{
+		return _height;
+	}
+
 protected:
 	void init_opengl(int width, int height)
 	{
@@ -131,6 +137,7 @@ protected:
 	GLuint _texid;
 	std::shared_ptr<cimbar::gl_2d_display> _display;
 	unsigned _width;
+	unsigned _height;
 	bool _good = true;
 };
 

--- a/src/lib/image_hash/test/CMakeLists.txt
+++ b/src/lib/image_hash/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(image_hash_test)
 

--- a/src/lib/image_hash/test/bitExtractorTest.cpp
+++ b/src/lib/image_hash/test/bitExtractorTest.cpp
@@ -92,14 +92,17 @@ TEST_CASE( "bitExtractorTest/testLargerValue.2", "[unit]" )
 
 TEST_CASE( "bitExtractorTest/testTuple.5", "[unit]" )
 {
-	uint64_t bits = 0x11d07e1f;
-	bit_extractor<uint64_t, 32, 5> be(bits);
+	uint64_t bits = 0x11d07e1f0;
+	bit_extractor<uint64_t, 36, 5> be(bits);
 
 	auto tup = be.pattern(0);
 	assertEquals( "0 7 14 21 28", tuple_to_str(tup) );
 
-	assertEquals(  0x2e8f00, be.extract(0, 7, 14, 21, 28) );
-	assertEquals(  0x2e8f00, be.extract_tuple(tup) );
+	assertEquals(  0x2, be.extract(0) );
+	assertEquals(  0x1E, be.extract(28) );
+	assertEquals(  0x17478, be.extract(0, 7, 14, 21) );
+	assertEquals(  0x2e8f1e, be.extract(0, 7, 14, 21, 28) );
+	assertEquals(  0x2e8f1e, be.extract_tuple(tup) );
 }
 
 TEST_CASE( "bitExtractorTest/testTuple.8", "[unit]" )
@@ -116,8 +119,8 @@ TEST_CASE( "bitExtractorTest/testTuple.8", "[unit]" )
 
 TEST_CASE( "bitExtractorTest/testTuplePatterns.5", "[unit]" )
 {
-	uint64_t bits = 0x11d07e1f;
-	bit_extractor<uint64_t, 32, 5> be(bits);
+	uint64_t bits = 0x11d07e1f0;
+	bit_extractor<uint64_t, 36, 5> be(bits);
 
 	std::tuple<unsigned, unsigned, unsigned, unsigned, unsigned> tup = be.pattern(0);
 	assertEquals( "0 7 14 21 28", tuple_to_str(tup) );

--- a/src/lib/util/vec_xy.h
+++ b/src/lib/util/vec_xy.h
@@ -5,15 +5,15 @@ namespace cimbar {
 
 struct vec_xy
 {
-	int x = 0;
-	int y = 0;
+	unsigned x = 0;
+	unsigned y = 0;
 
-	int width() const
+	unsigned width() const
 	{
 		return x;
 	};
 
-	int height() const
+	unsigned height() const
 	{
 		return y;
 	}

--- a/src/lib/util/vec_xy.h
+++ b/src/lib/util/vec_xy.h
@@ -1,0 +1,22 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+namespace cimbar {
+
+struct vec_xy
+{
+	int x = 0;
+	int y = 0;
+
+	int width() const
+	{
+		return x;
+	};
+
+	int height() const
+	{
+		return y;
+	}
+};
+
+}

--- a/src/third_party_lib/libcorrect/CMakeLists.txt
+++ b/src/third_party_lib/libcorrect/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(Correct C)
 include(CheckLibraryExists)
 include(CheckIncludeFiles)


### PR DESCRIPTION
The longstanding "5x5" experiment (see the table here: https://github.com/sz3/libcimbar/issues/69#issuecomment-1512393960) led to various ideas, very few of which (sadly) really worked out.

But we have some code cleanup as a result, some bugfixes, and some open areas of experiment. Notably, the next version of the format (0.7.0? Perhaps?) will likely introduce a "widescreen" (something like 16:10) mode that targets 720p cameras in addition to the current 1:1 square modes.

+ update build scripts since ubuntu 20.04 is eol
+ better window scaling (ok, it didn't even have window scaling) for cimbar_send now that I have discovered the glfw docs