### PR TITLE
Fix zstd skippable frame padding for small files

### DIFF
--- a/src/lib/compression/test/zstd_compressorTest.cpp
+++ b/src/lib/compression/test/zstd_compressorTest.cpp
@@ -115,3 +115,19 @@ TEST_CASE( "zstd_compressorTest/testRoundTrip.BigRandom.Buffs", "[unit]" )
 	assertEquals( original.size(), recovered.size() );
 	assertEquals( original, recovered );
 }
+
+TEST_CASE( "zstd_compressorTest/testPad", "[unit]" )
+{
+	zstd_compressor<std::stringstream> comp;
+	assertEquals( 0, comp.pad(20) );
+	assertEquals( 20, comp.size() );
+
+	std::stringstream output;
+	output << comp.rdbuf();
+
+	assertEquals( 20, output.str().size() );
+
+	char expected[] = "\x50\x2A\x4D\x18\x0c\x00\x00\x00" "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+	assertEquals( 21, sizeof(expected) );
+	assertEquals( std::string(expected, 20), output.str() );
+}

--- a/src/lib/compression/zstd_compressor.h
+++ b/src/lib/compression/zstd_compressor.h
@@ -77,10 +77,10 @@ public:
 		if (len < 9)
 			len = 9;
 
-		std::array<char, 8> header = {0x50, 0x2A, 0x4D, 0x18, (char)(len&0xFF), (char)(len&0xFF00 >> 8), (char)(len&0xFF0000 >> 16), 0};
+		len -= 8;
+		std::array<char, 8> header = {0x50, 0x2A, 0x4D, 0x18, (char)(len&0xFF), (char)((len&0xFF00) >> 8), (char)((len&0xFF0000) >> 16), 0};
 		STREAM::write(header.data(), header.size());
 
-		len -= 8;
 		std::fill(_compBuff.begin(), _compBuff.end(), 0);
 		for (size_t writeLen = CHUNK_SIZE; len > 0; len -= writeLen)
 		{

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -31,7 +31,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	Encoder enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xefcc8800efce8c48;
+	uint64_t hash = 0xeecc8800efce8808;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat encodedImg = cv::imread(path);
 	cv::cvtColor(encodedImg, encodedImg, cv::COLOR_BGR2RGB);
@@ -67,7 +67,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	enc.set_legacy_mode();
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xaecc8c00efce8c28;
+	uint64_t hash = 0xaecc8808efce9c08;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat encodedImg = cv::imread(path);
 	cv::cvtColor(encodedImg, encodedImg, cv::COLOR_BGR2RGB);

--- a/web/main.js
+++ b/web/main.js
@@ -24,11 +24,11 @@ function importFile(f)
 {
   const fileReader = new FileReader();
   fileReader.onload = (event) => {
-    const imageData = new Uint8Array(event.target.result);
-    const numBytes = imageData.length * imageData.BYTES_PER_ELEMENT;
+    const fileData = new Uint8Array(event.target.result);
+    const numBytes = fileData.length * fileData.BYTES_PER_ELEMENT;
     const dataPtr = Module._malloc(numBytes);
     const dataOnHeap = new Uint8Array(Module.HEAPU8.buffer, dataPtr, numBytes);
-    dataOnHeap.set(imageData);
+    dataOnHeap.set(fileData);
     Main.encode(f.name, dataOnHeap);
     Module._free(dataPtr);
 


### PR DESCRIPTION
This bug has been here from the start. :upside_down_face: 

*AFAIK* this doesn't manifest as anything, since the trailing padding seems to be reliably discarded (which is what we want). But the length calculation is *completely* wrong (for multiple kinds of wrong, in fact), so... let's fix it.

I *may* switch to `ZSTD_writeSkippableFrame()` for this, but with a proper test it's less compelling.