### PR TITLE
Include filename when sending/encoding a file + use it when receiving/decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(PROJECTS
 	src/exe/cimbar
 	src/exe/cimbar_extract
 	src/exe/cimbar_recv
+	src/exe/cimbar_recv2
 	src/exe/cimbar_send
 	src/exe/build_image_assets
 )

--- a/src/exe/cimbar/cimbar.cpp
+++ b/src/exe/cimbar/cimbar.cpp
@@ -13,7 +13,7 @@
 #include "cxxopts/cxxopts.hpp"
 
 #include <cstdio>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <string>
@@ -207,7 +207,7 @@ int main(int argc, char** argv)
 		return 0;
 	}
 
-	string outpath = std::experimental::filesystem::current_path().string();
+	string outpath = std::filesystem::current_path().string();
 	if (result.count("out"))
 		outpath = result["out"].as<string>();
 	std::cerr << "Output files will appear in " << outpath << std::endl;

--- a/src/exe/cimbar_recv/recv.cpp
+++ b/src/exe/cimbar_recv/recv.cpp
@@ -169,7 +169,7 @@ int main(int argc, char** argv)
 			if (res != 0)
 				std::cerr << "failed fountain_finish_copy " << res << std::endl;
 
-			write_on_store<cimbar::zstd_decompressor<std::ofstream>>(outpath, true)(filename, data);
+			decompress_on_store<std::ofstream>(outpath, true)(filename, data);
 		}
 	}
 

--- a/src/exe/cimbar_recv2/CMakeLists.txt
+++ b/src/exe/cimbar_recv2/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(cimbar_recv2)
+
+set (SOURCES
+	recv2.cpp
+)
+
+add_executable (
+	cimbar_recv2
+	${SOURCES}
+)
+
+target_link_libraries(cimbar_recv2
+
+	cimbar_js
+	extractor
+
+	GL
+	glfw
+	${OPENCV_LIBS}
+	opencv_videoio
+)
+
+add_custom_command(
+	TARGET cimbar_recv2 POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv2> cimbar_recv2.dbg
+	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv2>
+)
+

--- a/src/exe/cimbar_recv2/recv2.cpp
+++ b/src/exe/cimbar_recv2/recv2.cpp
@@ -1,22 +1,25 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "cimbar_js/cimbar_recv_js.h"
+
 #include "cimb_translator/Config.h"
 #include "compression/zstd_decompressor.h"
-#include "encoder/Decoder.h"
 #include "extractor/Extractor.h"
 #include "fountain/fountain_decoder_sink.h"
 #include "gui/window_glfw.h"
 
 #include "cxxopts/cxxopts.hpp"
+#include "serialize/format.h"
 #include "serialize/str.h"
-#include "serialize/str_join.h"
 
 #include <GLFW/glfw3.h>
 #include <opencv2/videoio.hpp>
 
 #include <chrono>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>
+#include <vector>
 using std::string;
 
 namespace {
@@ -38,7 +41,7 @@ int main(int argc, char** argv)
 
 	unsigned colorBits = cimbar::Config::color_bits();
 	unsigned ecc = cimbar::Config::ecc_bytes();
-	unsigned defaultFps = 30;
+	unsigned defaultFps = 15;
 	options.add_options()
 		("i,in", "Video source.", cxxopts::value<string>())
 		("o,out", "Output directory (decoding).", cxxopts::value<string>())
@@ -65,13 +68,15 @@ int main(int argc, char** argv)
 	colorBits = std::min(3, result["colorbits"].as<int>());
 	ecc = result["ecc"].as<unsigned>();
 
+	unsigned config_mode = 68;
 	bool legacy_mode = false;
 	if (result.count("mode"))
 	{
 		string mode = result["mode"].as<string>();
-		legacy_mode = (mode == "4c") or (mode == "4C");
+		if (mode == "4c" or mode == "4C")
+			config_mode = 4;
+		legacy_mode = config_mode == 4;
 	}
-	unsigned color_mode = legacy_mode? 0 : 1;
 
 	unsigned fps = result["fps"].as<unsigned>();
 	if (fps == 0)
@@ -105,11 +110,12 @@ int main(int argc, char** argv)
 	}
 	window.auto_scale_to_window();
 
-	Extractor ext;
-	Decoder dec(-1, -1);
+	// allocate buffers, etc
+	cimbard_configure_decode(colorBits, config_mode);
+	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, cimbar::Config::symbol_bits() + colorBits, legacy_mode);
 
-	unsigned chunkSize = cimbar::Config::fountain_chunk_size(ecc, colorBits+cimbar::Config::symbol_bits(), legacy_mode);
-	fountain_decoder_sink sink(chunkSize, decompress_on_store<std::ofstream>(outpath, true));
+	std::vector<unsigned char> bufspace;
+	bufspace.resize(cimbard_get_bufsize(), 0);
 
 	cv::Mat mat;
 
@@ -130,29 +136,41 @@ int main(int argc, char** argv)
 			continue;
 		}
 
-		cv::UMat img = mat.getUMat(cv::ACCESS_RW).clone();
+		cv::Mat img = mat.clone();
 		cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
 
 		// draw some stats on mat?
 		window.show(mat, 0);
 
-		// extract
-		bool shouldPreprocess = false;
-		int res = ext.extract(img, img);
-		if (!res)
+		// extract, decode, etc
+		int bytes = cimbard_scan_extract_decode(img.data, img.cols, img.rows, 3, bufspace.data(), bufspace.size());
+		if (bytes <= 0)
+			continue;
+
+		if (bytes % chunkSize != 0)
 		{
-			//std::cerr << "no extract " << mat.cols << "," << mat.rows << std::endl;
+			std::cerr << "WEIRD SEEMS BAD? " << count << std::endl;
 			continue;
 		}
-		else if (res == Extractor::NEEDS_SHARPEN)
-			shouldPreprocess = true;
 
-		// decode
-		int bytes = dec.decode_fountain(img, sink, color_mode, shouldPreprocess);
-		if (bytes > 0)
-			std::cerr << "got some bytes " << bytes << std::endl;
+		int64_t res = cimbard_fountain_decode(bufspace.data(), bytes);
+		if (res > 0)
+		{
+			// attempt save
+			uint32_t fileId = res;
 
-		std::cerr << turbo::str::join(sink.get_progress()) << std::endl;
+			unsigned size = cimbard_get_filesize(fileId);
+			std::string filename = fmt::format("0.{}", size);
+			std::cerr << "Saving file " << filename << " of size " << size << std::endl;
+
+			std::vector<unsigned char> data;
+			data.resize(size);
+			int res = cimbard_finish_copy(fileId, data.data(), size);
+			if (res != 0)
+				std::cerr << "failed fountain_finish_copy " << res << std::endl;
+
+			decompress_on_store<std::ofstream>(outpath, true)(filename, data);
+		}
 	}
 
 	return 0;

--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -94,18 +94,19 @@ int main(int argc, char** argv)
 			// TODO: maybe delay is the wrong thing to do here. Might be best to just kick out any files that fail to read?
 			// we can then error out properly if all inputs are bad, which would be nice.
 			{
-				string contents = File(infiles[i]).read_all();
+				const string& filename = infiles[i];
+				string contents = File(filename).read_all();
 				if (contents.empty())
 				{
-					std::cerr << "failed to read file " << infiles[i] << std::endl;
+					std::cerr << "failed to read file " << filename << std::endl;
 					continue;
 				}
 
 				// start encode_id is 109. This is mostly unimportant (it only needs to wrap between [0,127]), but useful
 				// for the decoder -- because it gives it a better distribution of colors in the first frame header it sees.
-				if (cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), static_cast<int>(i+109)) < 0)
+				if (cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), static_cast<int>(i+109)) < 0)
 				{
-					std::cerr << "failed to encode file " << infiles[i] << std::endl;
+					std::cerr << "failed to encode file " << filename << std::endl;
 					continue;
 				}
 			}

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -54,7 +54,7 @@ set (LINK_WASM_LIST
 	-s WASM_BIGINT=1
 	-s FILESYSTEM=0
 	-s TOTAL_MEMORY=134217728
-	-s EXPORTED_FUNCTIONS='["_cimbare_render","_cimbare_next_frame","_cimbare_encode","_cimbare_configure","_cimbare_get_aspect_ratio","_cimbard_get_report","_cimbard_scan_extract_decode","_cimbard_fountain_decode","_cimbard_get_bufsize","_cimbard_get_filesize","_cimbard_finish_copy","_cimbard_configure_decode","_cimbarz_init_decompress","_cimbarz_get_bufsize","_cimbarz_decompress_read","_malloc","_free"]'
+	-s EXPORTED_FUNCTIONS='["_cimbare_render","_cimbare_next_frame","_cimbare_encode","_cimbare_configure","_cimbare_get_aspect_ratio","_cimbard_get_report","_cimbard_scan_extract_decode","_cimbard_fountain_decode","_cimbard_get_bufsize","_cimbard_get_filesize","_cimbard_get_filename","_cimbard_finish_copy","_cimbard_configure_decode","_cimbarz_init_decompress","_cimbarz_get_bufsize","_cimbarz_decompress_read","_malloc","_free"]'
 )
 string(REPLACE ";" " " LINK_WASM_FLAGS "${LINK_WASM_LIST}")
 

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -113,7 +113,7 @@ int cimbare_next_frame()
 	return ++_frameCount;
 }
 
-int cimbare_encode(unsigned char* buffer, unsigned size, int encode_id)
+int cimbare_encode(const unsigned char* buffer, unsigned size, const char* filename, unsigned fnsize, int encode_id)
 {
 	_frameCount = 0;
 	if (!FountainInit::init())
@@ -131,8 +131,8 @@ int cimbare_encode(unsigned char* buffer, unsigned size, int encode_id)
 	else
 		enc.set_encode_id(static_cast<uint8_t>(encode_id));
 
-	cimbar::byte_istream bis(reinterpret_cast<char*>(buffer), size);
-	_fes = enc.create_fountain_encoder(bis, _compressionLevel);
+	cimbar::byte_istream bis(reinterpret_cast<const char*>(buffer), size);
+	_fes = enc.create_fountain_encoder(bis, std::string_view(filename, fnsize), _compressionLevel);
 
 	if (!_fes)
 		return -1; // return -1 plz

--- a/src/lib/cimbar_js/cimbar_js.h
+++ b/src/lib/cimbar_js/cimbar_js.h
@@ -9,7 +9,7 @@ extern "C" {
 int cimbare_init_window(int width, int height);
 int cimbare_render();
 int cimbare_next_frame();
-int cimbare_encode(unsigned char* buffer, unsigned size, int encode_id);  // encode_id == -1 -> auto-increment
+int cimbare_encode(const unsigned char* buffer, unsigned size, const char* filename, unsigned fnsize, int encode_id);  // encode_id == -1 -> auto-increment
 int cimbare_configure(unsigned color_bits, unsigned ecc, int compression, bool legacy_mode);
 float cimbare_get_aspect_ratio();
 

--- a/src/lib/cimbar_js/cimbar_recv_js.cpp
+++ b/src/lib/cimbar_js/cimbar_recv_js.cpp
@@ -8,6 +8,7 @@
 #include "extractor/Extractor.h"
 #include "fountain/fountain_decoder_sink.h"
 #include "serialize/str_join.h"
+#include "util/File.h"
 #include "util/Timer.h"
 
 #include <opencv2/opencv.hpp>
@@ -186,7 +187,7 @@ int cimbard_get_filename(const uchar* finbuffer, unsigned size, char* filename, 
 {
 	std::string fn = cimbar::zstd_header_check::get_filename(finbuffer, size);
 	if (!fn.empty())
-		fn = std::filesystem::path(fn).filename().string(); // strip path
+		fn = File::basename(fn);
 	if (fn.empty())
 		return 0;
 

--- a/src/lib/cimbar_js/cimbar_recv_js.cpp
+++ b/src/lib/cimbar_js/cimbar_recv_js.cpp
@@ -13,6 +13,7 @@
 #include <opencv2/opencv.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <memory>
 
 
@@ -184,6 +185,8 @@ int cimbard_get_filesize(uint32_t id)
 int cimbard_get_filename(const uchar* finbuffer, unsigned size, char* filename, unsigned fnsize)
 {
 	std::string fn = cimbar::zstd_header_check::get_filename(finbuffer, size);
+	if (!fn.empty())
+		fn = std::filesystem::path(fn).filename().string(); // strip path
 	if (fn.empty())
 		return 0;
 

--- a/src/lib/cimbar_js/cimbar_recv_js.h
+++ b/src/lib/cimbar_js/cimbar_recv_js.h
@@ -14,11 +14,11 @@ unsigned cimbard_get_debug(unsigned char* buff, unsigned maxlen);
 // imgsize=width*height*channels for rgba. Other formats are weirder.
 // output of scan is stored in `bufspace`
 int cimbard_get_bufsize();
-int cimbard_scan_extract_decode(unsigned char* imgdata, unsigned imgw, unsigned imgh, int format, unsigned char* bufspace, unsigned bufsize);
+int cimbard_scan_extract_decode(const unsigned char* imgdata, unsigned imgw, unsigned imgh, int format, unsigned char* bufspace, unsigned bufsize);
 
 // returns id of final file (can be used to get size of `finish_copy`'s buffer) if complete, 0 if success, negative on error
 // persists state, the return value (if >0) corresponds to a uint32_t id
-int64_t cimbard_fountain_decode(unsigned char* buffer, unsigned size);
+int64_t cimbard_fountain_decode(const unsigned char* buffer, unsigned size);
 
 // get filesize from id
 int cimbard_get_filesize(uint32_t id);
@@ -27,7 +27,10 @@ int cimbard_get_filesize(uint32_t id);
 // wherever a uint32_t id is passed, it should be on the same js thread
 // ... or at least in the same js shared memory...
 // as the fountain_decode() call
-int cimbard_finish_copy(uint32_t id, unsigned char* buffer, unsigned size);
+int cimbard_finish_copy(uint32_t id, unsigned char* finbuffer, unsigned size);
+
+// get filename from reassembled file
+int cimbard_get_filename(const unsigned char* finbuffer, unsigned size, char* filename, unsigned fnsize);
 
 int cimbard_configure_decode(unsigned color_bits, int mode_val);
 

--- a/src/lib/cimbar_js/cimbar_zstd_js.cpp
+++ b/src/lib/cimbar_js/cimbar_zstd_js.cpp
@@ -6,11 +6,6 @@
 #include <memory>
 #include <sstream>
 
-// wasm api will be something like
-// zstd_init_stream(bytes) -> constructor, reads skippable frame at start? (needs to for ofstream case)
-// get_filename(buff, size) -> cached in wasmjs api from constructor call?
-// get_bytes(buff, size) -> "decompress_chunk()/write()"
-
 namespace {
 	// maybe a map eventually
 	std::unique_ptr<cimbar::zstd_decompressor<std::stringstream>> _dec;
@@ -28,14 +23,6 @@ int cimbarz_init_decompress(unsigned char* buffer, unsigned size)
 	if (!_dec)
 		return -1;
 	_dec->init_decompress(reinterpret_cast<char*>(buffer), size);
-	return 0;
-}
-
-// cached in anon namespace from cimbarz_init_decompress call?
-int cimbarz_get_filename(char* buffer, unsigned size)
-{
-	if (!_dec)
-		return -1;
 	return 0;
 }
 

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -34,7 +34,13 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 	const int SIZE = 7000;
 	std::string contents = random_string(SIZE);
 
-	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), 100) );
+	// TODO: when this is foobar.txt, the transfer fails
+	// TODOOOOOOOO!
+	// let's investigate...
+	// also TODO: utf-8 (:
+	std::string filename = "aahahahahahahahaha.txt";
+
+	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), 100) );
 
 	assertEquals( 1, cimbare_next_frame() );
 
@@ -56,12 +62,19 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		uint32_t fileId = res;
 
 		unsigned size = cimbard_get_filesize(fileId);
-		assertEquals( 5247, size );
+		assertEquals( 5278, size );
 
 		std::vector<unsigned char> data;
 		data.resize(size);
 		int res = cimbard_finish_copy(fileId, data.data(), size);
 		assertEquals( 0, res );
+
+		std::string actualFilename;
+		actualFilename.resize(255);
+		int fnsz = cimbard_get_filename(data.data(), size, actualFilename.data(), actualFilename.size());
+		assertEquals( 22, fnsz );
+		actualFilename.resize(fnsz);
+		assertEquals( filename, actualFilename );
 
 		assertEquals(0, cimbarz_init_decompress(data.data(), data.size()));
 

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -33,13 +33,7 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 
 	const int SIZE = 7000;
 	std::string contents = random_string(SIZE);
-
-	// TODO: when this is foobar.txt, the transfer fails
-	// TODOOOOOOOO!
-	// let's investigate...
-	// also TODO: utf-8 (:
-	std::string filename = "aahahahahahahahaha.txt";
-
+	std::string filename = "/tmp/aahahahahahahahaha-c语言版.txt";
 	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), 100) );
 
 	assertEquals( 1, cimbare_next_frame() );
@@ -62,7 +56,7 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		uint32_t fileId = res;
 
 		unsigned size = cimbard_get_filesize(fileId);
-		assertEquals( 5278, size );
+		assertEquals( 5294, size );
 
 		std::vector<unsigned char> data;
 		data.resize(size);
@@ -72,9 +66,9 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		std::string actualFilename;
 		actualFilename.resize(255);
 		int fnsz = cimbard_get_filename(data.data(), size, actualFilename.data(), actualFilename.size());
-		assertEquals( 22, fnsz );
+		assertEquals( 33, fnsz );
 		actualFilename.resize(fnsz);
-		assertEquals( filename, actualFilename );
+		assertEquals( "aahahahahahahahaha-c语言版.txt", actualFilename );
 
 		assertEquals(0, cimbarz_init_decompress(data.data(), data.size()));
 

--- a/src/lib/cimbar_js/test/cimbar_recv_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_recv_jsTest.cpp
@@ -16,11 +16,11 @@
 namespace {
 	// a simple api for wirehair encoding
 	// might eventually expose something like these in the cimbare_* namespace
-	fountain_encoder_stream::ptr simp_wirehair_encode_init(unsigned char* buff, unsigned size, int compression_level)
+	fountain_encoder_stream::ptr simp_wirehair_encode_init(const unsigned char* buff, unsigned size, const char* filename, unsigned fnsize, int compression_level)
 	{
 		Encoder enc; // defaults
-		cimbar::byte_istream bis(reinterpret_cast<char*>(buff), size);
-		return enc.create_fountain_encoder(bis, compression_level);
+		cimbar::byte_istream bis(reinterpret_cast<const char*>(buff), size);
+		return enc.create_fountain_encoder(bis, std::string_view(filename, fnsize), compression_level);
 	}
 
 	int simp_wirehair_write(fountain_encoder_stream& fes, unsigned char* buff, unsigned size)
@@ -62,7 +62,10 @@ TEST_CASE( "cimbar_recv_jsTest/testWirehairReassemble", "[unit]" )
 
 	const int SIZE = 200000;
 	std::string contents = random_string(SIZE);
-	fountain_encoder_stream::ptr fes = simp_wirehair_encode_init(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), 0);
+
+	fountain_encoder_stream::ptr fes = simp_wirehair_encode_init(
+				reinterpret_cast<unsigned char*>(contents.data()), contents.size(),
+				nullptr, 0, 0);
 	assertTrue( fes );
 
 	int64_t dec = 0;

--- a/src/lib/compression/CMakeLists.txt
+++ b/src/lib/compression/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 set(SOURCES
 	zstd_compressor.h
 	zstd_decompressor.h
+	zstd_header_check.h
 )
 
 add_library(compression INTERFACE)

--- a/src/lib/compression/test/CMakeLists.txt
+++ b/src/lib/compression/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set (SOURCES
 	test.cpp
 	zstd_compressorTest.cpp
 	zstd_decompressorTest.cpp
+	zstd_header_checkTest.cpp
 )
 
 include_directories(

--- a/src/lib/compression/test/zstd_compressorTest.cpp
+++ b/src/lib/compression/test/zstd_compressorTest.cpp
@@ -119,7 +119,7 @@ TEST_CASE( "zstd_compressorTest/testRoundTrip.BigRandom.Buffs", "[unit]" )
 TEST_CASE( "zstd_compressorTest/testPad", "[unit]" )
 {
 	zstd_compressor<std::stringstream> comp;
-	assertEquals( 0, comp.pad(20) );
+	assertEquals( 20, comp.pad(20) );
 	assertEquals( 20, comp.size() );
 
 	std::stringstream output;

--- a/src/lib/compression/test/zstd_decompressorTest.cpp
+++ b/src/lib/compression/test/zstd_decompressorTest.cpp
@@ -95,3 +95,24 @@ TEST_CASE( "zstd_decompressorTest/testDecompress.ToFile", "[unit]" )
 	string actual = File(tempdir.path() / "decompress.txt").read_all();
 	assertEquals( expectedOutput.str(), actual );
 }
+
+TEST_CASE( "zstd_decompressorTest/testDecompress.Pad", "[unit]" )
+{
+	char inputC[] = "(\xb5" "/\xfd" "`\xe8\x02\x8d\x00\x00" "P0123456789\x01\x00\xdb[\x15$";
+	std::stringstream ss;
+	ss << string(inputC, 27);
+
+	std::stringstream expectedOutput;
+	for (int i = 0; i < 1000; i+=10)
+		expectedOutput << "0123456789";
+
+	zstd_decompressor<std::stringstream> dec;
+	assertEquals( 27, dec.decompress(ss) );
+
+	std::stringstream output;
+	output << dec.rdbuf();
+
+	assertEquals( 1000, output.str().size() );
+	assertEquals( expectedOutput.str(), output.str() );
+}
+

--- a/src/lib/compression/test/zstd_header_checkTest.cpp
+++ b/src/lib/compression/test/zstd_header_checkTest.cpp
@@ -1,0 +1,31 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+
+#include "zstd_compressor.h"
+#include "zstd_header_check.h"
+
+#include "serialize/format.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace cimbar;
+
+TEST_CASE( "zstd_header_checkTest/testGetFilename", "[unit]" )
+{
+	zstd_compressor<std::stringstream> comp;
+	std::string expectedfn = "foobar.txt";
+	assertEquals( 19, comp.write_header(expectedfn.data(), expectedfn.size()) );
+
+	std::stringstream output;
+	output << comp.rdbuf();
+
+	assertEquals( 19, output.str().size() );
+
+	char zstdblob[] = "\x50\x2A\x4D\x18\x0b\x00\x00\x00\x01" "foobar.txt";
+	assertEquals( 20, sizeof(zstdblob) );
+	assertEquals( std::string(zstdblob, sizeof(zstdblob)-1), output.str() );
+
+	std::string actualfn = zstd_header_check::get_filename(reinterpret_cast<unsigned char*>(zstdblob), sizeof(zstdblob)-1);
+	assertEquals( actualfn, expectedfn );
+}

--- a/src/lib/compression/zstd_compressor.h
+++ b/src/lib/compression/zstd_compressor.h
@@ -88,9 +88,9 @@ public:
 
 	size_t write_header(const char* data, unsigned len)
 	{
-		// todo: I don't like the api -- requires us to fold everything into the buff at once.
-		// would rather do it piecemeal, e.g. roll my own. Seems simple enough. Maybe test this time...
-		size_t writ = ZSTD_writeSkippableFrame(_compBuff.data(), _compBuff.size(), data, len, 0);
+		std::string temp = "\x01";
+		temp += std::string(data, len);
+		size_t writ = ZSTD_writeSkippableFrame(_compBuff.data(), _compBuff.size(), temp.data(), temp.size(), 0);
 		STREAM::write(_compBuff.data(), writ);
 		return writ;
 	}

--- a/src/lib/compression/zstd_compressor.h
+++ b/src/lib/compression/zstd_compressor.h
@@ -77,8 +77,6 @@ public:
 		if (len < 9)
 			len = 9;
 
-		// test what this actually does with ZSTD_isSkippableFrame and ZSTD_readSkippableFrame
-		// then, replace it with ZSTD_writeSkippableFrame...
 		std::string temp(len-8, '\0');
 		size_t writ = ZSTD_writeSkippableFrame(_compBuff.data(), _compBuff.size(), temp.data(), temp.size(), 0);
 
@@ -89,7 +87,7 @@ public:
 	size_t write_header(const char* data, unsigned len)
 	{
 		std::string temp = "\x01";
-		temp += std::string(data, len);
+		temp += std::string_view(data, len);
 		size_t writ = ZSTD_writeSkippableFrame(_compBuff.data(), _compBuff.size(), temp.data(), temp.size(), 0);
 		STREAM::write(_compBuff.data(), writ);
 		return writ;

--- a/src/lib/compression/zstd_header_check.h
+++ b/src/lib/compression/zstd_header_check.h
@@ -1,0 +1,35 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include "zstd/zstd.h"
+#include <string>
+
+namespace cimbar {
+
+class zstd_header_check
+{
+public:
+	static std::string get_filename(const unsigned char* data, size_t len)
+	{
+		if (!ZSTD_isSkippableFrame(data, len))
+			return "";
+
+		std::string res;
+		res.resize(500, '\0');
+		size_t sz = ZSTD_readSkippableFrame(res.data(), res.size(), nullptr, data, len);
+		if (sz <= 1)
+			return "";
+
+		switch (res[0])
+		{
+			case 1:
+				return std::string(&res[1], sz-1);
+			default:
+				break;
+		}
+		return "";
+	}
+
+};
+
+}

--- a/src/lib/encoder/Encoder.h
+++ b/src/lib/encoder/Encoder.h
@@ -24,7 +24,7 @@ public:
 	std::optional<cv::Mat> encode_next(STREAM& stream, cimbar::vec_xy canvas_size={});
 
 	template <typename STREAM>
-	fountain_encoder_stream::ptr create_fountain_encoder(STREAM& stream, int compression_level=6);
+	fountain_encoder_stream::ptr create_fountain_encoder(STREAM& stream, const std::string_view& filename, int compression_level=16);
 
 protected:
 	template <typename STREAM>
@@ -164,7 +164,7 @@ inline std::optional<cv::Mat> Encoder::encode_next_coupled(STREAM& stream, cimba
 }
 
 template <typename STREAM>
-inline fountain_encoder_stream::ptr Encoder::create_fountain_encoder(STREAM& stream, int compression_level)
+inline fountain_encoder_stream::ptr Encoder::create_fountain_encoder(STREAM& stream, const std::string_view& filename, int compression_level)
 {
 	unsigned chunk_size = cimbar::Config::fountain_chunk_size(_eccBytes, _bitsPerColor + _bitsPerSymbol, (_colorMode==0 and _coupled));
 
@@ -174,6 +174,8 @@ inline fountain_encoder_stream::ptr Encoder::create_fountain_encoder(STREAM& str
 	else
 	{
 		cimbar::zstd_compressor<std::stringstream> f;
+		if (!filename.empty())
+			f.write_header(filename.data(), filename.size());
 		if (!f.compress(stream))
 			return nullptr;
 

--- a/src/lib/encoder/EncoderPlus.h
+++ b/src/lib/encoder/EncoderPlus.h
@@ -7,6 +7,7 @@
 #include "serialize/format.h"
 
 #include <opencv2/opencv.hpp>
+#include <filesystem>
 #include <functional>
 #include <string>
 
@@ -43,7 +44,7 @@ inline unsigned EncoderPlus::encode(const std::string& filename, std::string out
 inline unsigned EncoderPlus::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy)
 {
 	std::ifstream infile(filename, std::ios::binary);
-	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, compression_level);
+	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, std::filesystem::path(filename).filename().string(), compression_level);
 	if (!fes)
 		return 0;
 

--- a/src/lib/encoder/EncoderPlus.h
+++ b/src/lib/encoder/EncoderPlus.h
@@ -5,6 +5,7 @@
 #include "cimb_translator/Config.h"
 #include "extractor/Scanner.h"
 #include "serialize/format.h"
+#include "util/File.h"
 
 #include <opencv2/opencv.hpp>
 #include <filesystem>
@@ -44,7 +45,7 @@ inline unsigned EncoderPlus::encode(const std::string& filename, std::string out
 inline unsigned EncoderPlus::encode_fountain(const std::string& filename, const std::function<bool(const cv::Mat&, unsigned)>& on_frame, int compression_level, double redundancy)
 {
 	std::ifstream infile(filename, std::ios::binary);
-	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, std::filesystem::path(filename).filename().string(), compression_level);
+	fountain_encoder_stream::ptr fes = create_fountain_encoder(infile, File::basename(filename), compression_level);
 	if (!fes)
 		return 0;
 

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -93,7 +93,7 @@ TEST_CASE( "EncoderTest/testFountain.Compress", "[unit]" )
 	EncoderPlus enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix) );
 
-	uint64_t hash = 0xa66a666543280e8e;
+	uint64_t hash = 0x84883d01a75f36cf;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
 	assertEquals( hash, image_hash::average_hash(img) );
@@ -107,19 +107,20 @@ TEST_CASE( "EncoderTest/testPiecemealFountainEncoder", "[unit]" )
 
 	std::string inputFile = TestCimbar::getProjectDir() + "/LICENSE";
 	std::string contents = File(inputFile).read_all();
+	assertEquals( 16727, contents.size() );
 
 	cimbar::byte_istream bis(contents.data(), contents.size());
 	// equivalent to:
 	// cimbar::bytebuf bb(contents.data(), contents.size());
 	// std::istream is(&bb);
 
-	fountain_encoder_stream::ptr fes = enc.create_fountain_encoder(bis);
+	fountain_encoder_stream::ptr fes = enc.create_fountain_encoder(bis, "LICENSE.txt");
 	assertTrue( fes );
 
 	std::optional<cv::Mat> frame = enc.encode_next(*fes);
 	assertTrue( frame );
 
-	uint64_t hash = 0xa810f60b46fb87b9;
+	uint64_t hash = 0xef84e600f45efa9;
 	assertEquals( hash, image_hash::average_hash(*frame) );
 }
 
@@ -133,7 +134,7 @@ TEST_CASE( "EncoderTest/testFountain.Size", "[unit]" )
 	EncoderPlus enc(30, 4, 2);
 	assertEquals( 1, enc.encode_fountain(inputFile, outPrefix, 16, 1.6) );
 
-	uint64_t hash = 0xa66a666543280e8e;
+	uint64_t hash = 0x84883d01a75f36cf;
 	std::string path = fmt::format("{}_0.png", outPrefix);
 	cv::Mat img = cv::imread(path);
 	assertEquals( 1024, img.rows );

--- a/src/lib/fountain/concurrent_fountain_decoder_sink.h
+++ b/src/lib/fountain/concurrent_fountain_decoder_sink.h
@@ -9,7 +9,7 @@
 class concurrent_fountain_decoder_sink
 {
 public:
-	concurrent_fountain_decoder_sink(unsigned chunk_size, const std::function<void(const std::string&, const std::vector<uint8_t>&)>& on_store=nullptr)
+	concurrent_fountain_decoder_sink(unsigned chunk_size, const std::function<std::string(const std::string&, const std::vector<uint8_t>&)>& on_store=nullptr)
 		: _decoder(chunk_size, on_store)
 	{
 	}

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -6,6 +6,7 @@
 #include "compression/zstd_decompressor.h"
 #include "compression/zstd_header_check.h"
 #include "serialize/format.h"
+#include "util/File.h"
 
 #include <cstdio>
 #include <filesystem>
@@ -35,7 +36,7 @@ std::function<std::string(const std::string&, const std::vector<uint8_t>&)> deco
 	{
 		std::string filename = cimbar::zstd_header_check::get_filename(data.data(), data.size());
 		if (!filename.empty())
-			filename = std::filesystem::path(filename).filename().string(); // strip path
+			filename = File::basename(filename);
 		if (filename.empty())
 			filename = fallback_name;
 

--- a/src/lib/fountain/test/CMakeLists.txt
+++ b/src/lib/fountain/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_test(fountain_test fountain_test)
 
 target_link_libraries(fountain_test
 	wirehair
+	zstd
 
 	${CPPFILESYSTEM}
 )

--- a/src/lib/util/File.h
+++ b/src/lib/util/File.h
@@ -3,11 +3,18 @@
 
 #include <array>
 #include <cstdio>
+#include <filesystem>
 #include <iostream>
 #include <string>
 
 class File
 {
+public:
+	static std::string basename(const std::string& fullpath)
+	{
+		return std::filesystem::path(fullpath).filename().string();
+	}
+
 public:
 	File(std::string filename, bool write=false)
 	{

--- a/src/lib/util/MakeTempDirectory.h
+++ b/src/lib/util/MakeTempDirectory.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include <cstdio>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <string>
 
 class MakeTempDirectory
@@ -12,7 +12,7 @@ public:
 		: _cleanup(cleanup)
 	{
 		_path = std::tmpnam(nullptr);
-		std::experimental::filesystem::create_directory(_path);
+		std::filesystem::create_directory(_path);
 	}
 
 	~MakeTempDirectory()
@@ -20,16 +20,16 @@ public:
 		if (_cleanup)
 		{
 			std::error_code ec;
-			std::experimental::filesystem::remove_all(_path, ec);
+			std::filesystem::remove_all(_path, ec);
 		}
 	}
 
-	std::experimental::filesystem::path path() const
+	std::filesystem::path path() const
 	{
 		return _path;
 	}
 
 protected:
 	bool _cleanup;
-	std::experimental::filesystem::path _path;
+	std::filesystem::path _path;
 };

--- a/src/third_party_lib/zstd/CMakeLists.txt
+++ b/src/third_party_lib/zstd/CMakeLists.txt
@@ -9,3 +9,4 @@ set(zstd_obj_files $<TARGET_OBJECTS:zstd-common> $<TARGET_OBJECTS:zstd-compress>
 
 add_library(zstd ${zstd_obj_files})
 
+target_compile_options(zstd  PUBLIC "-DZSTD_STATIC_LINKING_ONLY")

--- a/web/recv.js
+++ b/web/recv.js
@@ -69,7 +69,7 @@ var Sink = function () {
           const fnsize = Module._cimbard_get_filename(buff.byteOffset, buff.length, _errBuff, _errBuffSize);
           if (fnsize > 0) {
             const temparr = new Uint8Array(Module.HEAPU8.buffer, _errBuff, fnsize);
-            name = new TextDecoder().decode(temparr);
+            name = new TextDecoder("utf-8").decode(temparr);
           }
           //Recv.download_bytes(buff, size + ".zst"); // size -> name, eventually
           Zstd.decompress(name, buff);


### PR DESCRIPTION
For https://github.com/sz3/libcimbar/issues/88 .

The idea is that we have a skippable zstd frame with metadata at the start of the encoded file, and check for it when decoding. If the metadata frame fails to decode, or doesn't exist (as will be the case for any encoder <0.6.2), we fall back to the previous behavior.

Follow up to #134 .

