### PR TITLE
Fix color correction flaw introduced in 0.6.0

### DIFF
--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -20,7 +20,7 @@ public:
 	bool done() const;
 
 	void init_ccm(unsigned color_bits, unsigned interleave_blocks, unsigned interleave_partitions, unsigned fountain_blocks);
-	void update_metadata(char* buff, unsigned len);
+	void update_metadata(char* buff, unsigned len, unsigned chunk_size);
 
 	unsigned num_reads() const;
 
@@ -28,6 +28,7 @@ protected:
 	cv::Mat _image;
 	bitbuffer _grayscale;
 	FountainMetadata _fountainColorHeader;
+	unsigned _radioactiveBlockId;
 
 	unsigned _cellSize;
 	FloodDecodePositions _positions;

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -186,7 +186,7 @@ TEST_CASE( "CimbReaderTest/testCCM", "[unit]" )
 	// this is the header value for the sample -- we could imitate what the Decoder does
 	// and compute it from the symbols, but that seems like overkill for this test.
 	FountainMetadata md(0, 23586, 7);
-	cr.update_metadata((char*)md.data(), md.md_size);
+	cr.update_metadata((char*)md.data(), md.md_size, 625);
 	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(), cimbar::Config::fountain_chunks_per_frame(6, false));
 
 	assertTrue( decoder.get_ccm().active() );
@@ -242,7 +242,7 @@ TEST_CASE( "CimbReaderTest/testCCM.VeryNecessary", "[unit]" )
 	// this is the header value for the sample -- we could imitate what the Decoder does
 	// and compute it from the symbols, but that seems like overkill for this test.
 	FountainMetadata md(0, 23586, 7);
-	cr.update_metadata((char*)md.data(), md.md_size);
+	cr.update_metadata((char*)md.data(), md.md_size, 625);
 	cr.init_ccm(2, cimbar::Config::interleave_blocks(), cimbar::Config::interleave_partitions(), cimbar::Config::fountain_chunks_per_frame(6, false));
 
 	assertTrue( decoder.get_ccm().active() );

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -33,7 +33,7 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 
 	const int SIZE = 7000;
 	std::string contents = random_string(SIZE);
-	std::string filename = "/tmp/aahahahahahahahaha-c语言版.txt";
+	std::string filename = "/tmp/foobar-c语言版.txt";
 	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), 100) );
 
 	assertEquals( 1, cimbare_next_frame() );
@@ -56,7 +56,7 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		uint32_t fileId = res;
 
 		unsigned size = cimbard_get_filesize(fileId);
-		assertEquals( 5294, size );
+		assertEquals( 5282, size );
 
 		std::vector<unsigned char> data;
 		data.resize(size);
@@ -66,9 +66,9 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		std::string actualFilename;
 		actualFilename.resize(255);
 		int fnsz = cimbard_get_filename(data.data(), size, actualFilename.data(), actualFilename.size());
-		assertEquals( 33, fnsz );
+		assertEquals( 21, fnsz );
 		actualFilename.resize(fnsz);
-		assertEquals( "aahahahahahahahaha-c语言版.txt", actualFilename );
+		assertEquals( "foobar-c语言版.txt", actualFilename );
 
 		assertEquals(0, cimbarz_init_decompress(data.data(), data.size()));
 

--- a/src/lib/encoder/Decoder.h
+++ b/src/lib/encoder/Decoder.h
@@ -163,7 +163,7 @@ inline unsigned Decoder::decode_fountain(const MAT& img, FOUNTAINSTREAM& ostream
 	CimbReader reader(img, _decoder, color_mode, should_preprocess, color_correction);
 	bool legacy_mode = color_mode == 0;
 	unsigned chunk_size = cimbar::Config::fountain_chunk_size(_eccBytes, _bitsPerOp, legacy_mode);
-	auto update_md_fun = std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2);
+	auto update_md_fun = std::bind(&CimbReader::update_metadata, &reader, std::placeholders::_1, std::placeholders::_2, chunk_size);
 
 	// we don't want to feed the fountain stream bad data, so we eat the decode if we have a mismatch
 	// we still might succeed the decode, in which case (hopefully) the positive bytes we return will

--- a/src/lib/fountain/FountainMetadata.h
+++ b/src/lib/fountain/FountainMetadata.h
@@ -65,9 +65,12 @@ public:
 		return res;
 	}
 
-	void increment_block_id()
+	void increment_block_id(unsigned radioactive_block_id)
 	{
-		update_block_id_internal(block_id()+1, _data.data()+4);
+		unsigned next = block_id()+1;
+		if (next == radioactive_block_id)
+			next += 1;
+		update_block_id_internal(next, _data.data()+4);
 	}
 
 	unsigned file_size() const


### PR DESCRIPTION
When we added the split symbol/color decode and the motivating color correction logic, that included a potential issue where said logic might get confused by the very specific case of the final "normal" block of the fountain encode.

As a refresher: wirehair encodes the initial file verbatim as its initial N blocks -- only after exhausting these initial file bytes does it begin its (almost magical) GF256-inspired permutations. Each block up to the final of these initial N will be exactly the expected block size, and each of the successive ones will also match exactly. But the one at the tail end, provided the block size and file size do not divide perfectly (which will be the normal case), will be smaller. We want all the blocks to exactly match, so the encoder skips that one. (example: block size 22, file size 100. After the 0th through 3rd blocks, we'll have 12 bytes remaining, meaning block_id=4 will be smaller than expected. So the next block we'll send will be block_id=5)

The color correction logic exploits the presence of a deterministic header -- which contains the block_id as its trailing 2 bytes. We can do one of the following:
* use the first 4 bytes of the header, ignoring the block_id, because it changes. (This is what I did in my initial python implementation)
* use all 6 bytes, risking disaster(?) -- a failed color decode -- in the rare case where the color correction algorithm becomes confused by having the wrong block_id. (I expected it could fail, but had never seen it...)
* or ... use all 6 bytes, and handle the special case where we skip one of the block_ids.

We're now doing option (3).

Follow up to #134, #135, and #91.

I'm not sure how frequent this problem was in the wild, but it would've manifested only for very small files.