### PR TITLE
fix build

### DIFF
--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -8,7 +8,7 @@ set (SOURCES
 )
 
 # only if we're using wasm
-if(USE_WASM EQUAL "1")
+if(NOT USE_WASM EQUAL "2")
 set(SOURCES
 	${SOURCES}
 
@@ -61,7 +61,7 @@ set (LINK_WASM_EXPORTED_FUNCTIONS
 	"_cimbare_get_aspect_ratio"
 )
 
-if(USE_WASM EQUAL "1")
+if(NOT USE_WASM EQUAL "2")
 set(LINK_WASM_EXPORTED_FUNCTIONS
 	${LINK_WASM_EXPORTED_FUNCTIONS}
 


### PR DESCRIPTION
Go carried away and pushed a "small build update" to master (to shrink the size of the single file cimbar.js build).

https://github.com/sz3/libcimbar/commit/763a684b12d4c2ed3f409daeb7d1f01843e59efe

Of course I got the cmake syntax wrong and broke the build. Anyway, taking my medicine and making a PR