### PR TITLE
Improve encode c api

### DIFF
--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -103,11 +103,21 @@ int main(int argc, char** argv)
 					continue;
 				}
 
-				// start encode_id is 109. This is mostly unimportant (it only needs to wrap between [0,127]), but useful
-				// for the decoder -- because it gives it a better distribution of colors in the first frame header it sees.
-				if (cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), static_cast<int>(i+109)) < 0)
+				if (cimbare_init_encode(filename.data(), filename.size(), -1) < 0)
 				{
-					std::cerr << "failed to encode file " << filename << std::endl;
+					std::cerr << "failed to 'init encode' file " << filename << std::endl;
+					continue; // abort??
+				}
+
+				int res = cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size());
+				if (res < 0)
+				{
+					std::cerr << "failed to compress file " << filename << std::endl;
+					continue;
+				}
+				else if (res == 1 and cimbare_encode(nullptr, 0) != 0) // fallback finish encode
+				{
+					std::cerr << "failed to encode for file" << filename << std::endl;
 					continue;
 				}
 			}

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -54,7 +54,9 @@ set (LINK_WASM_EXPORTED_FUNCTIONS
 	, "_free"
 	, "_cimbare_render"
 	, "_cimbare_next_frame"
+	, "_cimbare_init_encode"
 	, "_cimbare_encode"
+	, "_cimbare_encode_bufsize"
 	, "_cimbare_configure"
 	, "_cimbare_get_aspect_ratio"
 )

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -140,6 +140,8 @@ int cimbare_init_encode(const char* filename, unsigned fnsize, int encode_id)
 
 	if (fnsize > 0 and filename != nullptr)
 		_comp->write_header(filename, fnsize);
+
+	_fes.reset();
 	return 0;
 }
 

--- a/src/lib/cimbar_js/cimbar_js.h
+++ b/src/lib/cimbar_js/cimbar_js.h
@@ -9,7 +9,9 @@ extern "C" {
 int cimbare_init_window(int width, int height);
 int cimbare_render();
 int cimbare_next_frame();
-int cimbare_encode(const unsigned char* buffer, unsigned size, const char* filename, unsigned fnsize, int encode_id);  // encode_id == -1 -> auto-increment
+int cimbare_init_encode(const char* filename, unsigned fnsize, int encode_id);
+int cimbare_encode_bufsize();
+int cimbare_encode(const unsigned char* buffer, unsigned size);
 int cimbare_configure(int mode_val, int compression);
 float cimbare_get_aspect_ratio();
 

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -33,7 +33,8 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 	const int SIZE = 7000;
 	std::string contents = random_string(SIZE);
 	std::string filename = "/tmp/foobar-c语言版.txt";
-	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size(), filename.data(), filename.size(), 100) );
+	assertEquals( 0, cimbare_init_encode(filename.data(), filename.size(), 100) );
+	assertEquals( 0, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size()) );
 
 	assertEquals( 1, cimbare_next_frame() );
 

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -66,11 +66,30 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 		zstdbuff.resize(cimbard_get_decompress_bufsize());
 
 		int outsize = cimbard_decompress_read(fileId, zstdbuff.data(), zstdbuff.size());
-		assertEquals(contents.size(), outsize);
+		assertTrue( outsize > 0 );
+		assertEquals(contents.size(), (unsigned)outsize);
 		std::string_view finalOutput{reinterpret_cast<char*>(zstdbuff.data()), contents.size()};
 
 		assertEquals(contents, finalOutput);
 	}
 
+}
+
+TEST_CASE( "cimbar_jsTest/testEncodeFlushNoop", "[unit]" )
+{
+	std::vector<unsigned char> decbuff;
+	decbuff.resize(cimbard_get_bufsize());
+
+	const int size = cimbare_encode_bufsize();
+	std::string contents = random_string(size);
+	std::string filename = "/tmp/foobar-c语言版.txt";
+	assertEquals( 0, cimbare_init_encode(filename.data(), filename.size(), 100) );
+	assertEquals( 1, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size()) );
+	assertEquals( -1, cimbare_next_frame() );
+
+	assertEquals( 0, cimbare_encode(nullptr, 0) );
+	assertEquals( 1, cimbare_next_frame() );
+
+	assertEquals( -1, cimbare_encode(nullptr, 0) );
 }
 

--- a/src/lib/compression/zstd_compressor.h
+++ b/src/lib/compression/zstd_compressor.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 namespace cimbar {
 
@@ -14,6 +15,7 @@ class zstd_compressor : public STREAM
 {
 public:
 	using STREAM::STREAM; // pull in constructors
+	static const size_t CHUNK_SIZE = 0x4000;
 
 public:
 	~zstd_compressor()
@@ -22,6 +24,8 @@ public:
 			ZSTD_freeCCtx(_cctx);
 	}
 
+	// if you call write directly, len should be a multiple of CHUNK_SIZE
+	// .. or the final bytes of the input
 	bool write(const char* data, size_t len)
 	{
 		size_t writeLen = CHUNK_SIZE;
@@ -102,7 +106,6 @@ public:
 	}
 
 protected:
-	static const size_t CHUNK_SIZE = 0x4000;
 	int _compressionLevel = 16;
 	ZSTD_CCtx* _cctx = ZSTD_createCCtx();
 	std::vector<char> _compBuff = std::vector<char>(ZSTD_compressBound(CHUNK_SIZE));


### PR DESCRIPTION
The flip side of https://github.com/sz3/libcimbar/pull/144: *complex-ify* the encoder. :melting_face: 

We (users of the cimbar.js encoder, including me) have run into situations where the browser hits an out of memory (OOM) error on large input files. Example issues:
https://github.com/sz3/libcimbar/issues/141
https://github.com/sz3/libcimbar/issues/132
https://github.com/sz3/libcimbar/issues/118
https://github.com/sz3/libcimbar/issues/96

While I can't solve all OOM issues -- wirehair needs the compressed representation stored in contiguous memory -- writing the decoder (#134) reminded/convinced me that we can do better when loading the *uncompressed* data for encoding.

So:
* we're now loading input files in chunks
* this requires us to change the c api for encoding
* as a result, OOM errors in the browser should be less frequent. I won't say solved; but, better. 

The new API surface:
* `cimbare_init_encode(filename, encode_id)` -> starts an encode, waits for data
* `cimbare_encode(data)` -> provides data. When the size of data provided is == `cimbare_encode_bufsize()`, we treat this as an incremental write and don't finalize anything (and return `1`). Otherwise, we consider the write complete.
* `cimbare_encode(nullptr, 0)` therefore functions as a sort of "flush()" operation if you want to make sure the data is ready.
* when cimbare_encode() returns `0`, we can start doing our `cimbare_next_frame()` calls