### PR TITLE
cimbar_send cli: fix high DPI scaling on wayland

### DIFF
--- a/src/exe/cimbar_send/send.cpp
+++ b/src/exe/cimbar_send/send.cpp
@@ -6,6 +6,7 @@
 #include "util/File.h"
 
 #include "cxxopts/cxxopts.hpp"
+#include <GLFW/glfw3.h>
 
 #include <chrono>
 #include <iostream>
@@ -79,6 +80,9 @@ int main(int argc, char** argv)
 	if (fps == 0)
 		fps = defaultFps;
 	unsigned delay = 1000 / fps;
+
+	// GLFW high DPI hack
+	glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
 
 	int window_size_x = cimbar::Config::image_size_x();
 	int window_size_y = cimbar::Config::image_size_y();

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -102,7 +102,7 @@ public:
 			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 			glViewport(xOffset, yOffset, viewportWidth, viewportHeight);
 		};
-		glfwSetWindowSizeCallback(_w, fun);
+		glfwSetFramebufferSizeCallback(_w, fun);
 	}
 
 	void resize(unsigned width, unsigned height)


### PR DESCRIPTION
* switch to glfwSetFramebufferSizeCallback(), but only on desktop. wasm code relies on browser-side resize logic)
* using glfwWindowHint() on desktop-only code paths (also not in the wasm)
* not sure about future impacts on windows/mac, let me know if you try to get it working and it doesn't look right

See also: #128, #159