### PR TITLE
Minor webui improvements

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -25,12 +25,21 @@ var Main = function () {
     }
   }
 
-  function importFile(file) {
-    let chunkSize = Module._cimbare_encode_bufsize();
+  function compress_buff(chunkSize) {
     if (_compressBuff === undefined) {
       const dataPtr = Module._malloc(chunkSize);
       _compressBuff = new Uint8Array(Module.HEAPU8.buffer, dataPtr, chunkSize);
     }
+    else if (_compressBuff.buffer !== Module.HEAPU8.buffer) {
+      _compressBuff = new Uint8Array(Module.HEAPU8.buffer, _compressBuff.byteOffset, _compressBuff.byteLength);
+    }
+    return _compressBuff;
+  }
+
+  function importFile(file) {
+    let chunkSize = Module._cimbare_encode_bufsize();
+    let compBuff = compress_buff(chunkSize);
+
     let offset = 0;
     let reader = new FileReader();
 
@@ -41,8 +50,9 @@ var Main = function () {
       if (datalen > 0) {
         // copy to wasm buff and write
         const uint8View = new Uint8Array(event.target.result);
-        _compressBuff.set(uint8View);
-        const buffView = new Uint8Array(Module.HEAPU8.buffer, _compressBuff.byteOffset, datalen);
+        compBuff = compress_buff(chunkSize);
+        compBuff.set(uint8View);
+        const buffView = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, datalen);
         Main.encode_bytes(buffView);
 
         offset += chunkSize;
@@ -53,7 +63,7 @@ var Main = function () {
 
         // this null call is functionally a flush()
         // so a no-op, unless it isn't
-        const nullBuff = new Uint8Array(Module.HEAPU8.buffer, _compressBuff.byteOffset, 0);
+        const nullBuff = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, 0);
         Main.encode_bytes(nullBuff);
       }
     };

--- a/web/recv-worker.js
+++ b/web/recv-worker.js
@@ -99,11 +99,21 @@ var RecvWorker = function () {
     },
 
     imgBuff: function () {
-      return _buffs['img'];
+      let buff = _buffs['img'];
+      if (buff.buffer !== Module.HEAPU8.buffer) {
+        _buffs['img'] = new Uint8Array(Module.HEAPU8.buffer, buff.byteOffset, buff.byteLength);
+        buff = _buffs['img'];
+      }
+      return buff;
     },
 
     fountainBuff: function () {
-      return _buffs['fountain'];
+      let buff = _buffs['fountain'];
+      if (buff.buffer !== Module.HEAPU8.buffer) {
+        _buffs['img'] = new Uint8Array(Module.HEAPU8.buffer, buff.byteOffset, buff.byteLength);
+        buff = _buffs['fountain'];
+      }
+      return buff;
     }
   };
 }();

--- a/web/recv.js
+++ b/web/recv.js
@@ -119,6 +119,57 @@ var Recv = function () {
     return isIOS || (isAppleDevice && isTouchScreen);
   }
 
+  function _getModeAspectRatio(mode) {
+    // (image_size_x + 16) / (image_size_y + 16)
+    switch (mode) {
+      case 66: return 1.1516; // Bu
+      case 67: return 1.413;  // Bm
+      default: return 1.0;    // B, 4C, auto
+    }
+  }
+
+  function _updateCrosshairPositions() {
+    if (!_video || !_video.videoWidth || !_video.videoHeight)
+      return;
+
+    var modeAspect = _getModeAspectRatio(_mode);
+
+    var windowW = window.innerWidth;
+    var windowH = window.innerHeight;
+    var camAspect = _video.videoWidth / _video.videoHeight;
+    var windowAspect = windowW / windowH;
+
+    var vidW = windowW;
+    var vidH = windowH;
+    if (camAspect > windowAspect)  // black bars top/bottom
+      vidH = vidW / camAspect;
+    else  // black bars left/right
+      vidW = vidH * camAspect;
+
+    var offsetY;
+    var offsetX;
+    if (windowH > windowW) {
+      // portrait
+      offsetY = (windowH - (vidW * modeAspect)) / 2;
+      offsetX = (windowW - vidW) / 2;
+    }
+    else {
+      offsetY = (windowH - vidH) / 2;
+      offsetX = (windowW - (vidH * modeAspect)) / 2;
+    }
+
+    var logme = "crosshair offsets now " + offsetX + ", " + offsetY;
+    //Recv.set_error(logme);
+    console.log(logme);
+
+    var xh1 = document.getElementById("crosshair1");
+    var xh2 = document.getElementById("crosshair2");
+    xh1.style.top = offsetY + "px";
+    xh1.style.right = offsetX + "px";
+    xh2.style.bottom = offsetY + "px";
+    xh2.style.left = offsetX + "px";
+  }
+
   // public interface
   return {
     init: function (video, num_workers) {
@@ -163,6 +214,7 @@ var Recv = function () {
 
     init_video: function (video) {
       _video = video;
+      window.addEventListener('resize', _updateCrosshairPositions);
 
       var constraints = {
         audio: false,
@@ -340,6 +392,8 @@ var Recv = function () {
     },
 
     update_visual_state: function () {
+      _updateCrosshairPositions();
+
       // check counters
       var xh1 = document.getElementById("crosshair1");
       var xh2 = document.getElementById("crosshair2");

--- a/web/recv.js
+++ b/web/recv.js
@@ -4,6 +4,13 @@ var Sink = function () {
   var _errBuff = undefined;
   var _errBuffSize = 1024;
 
+  function fountain_buff() {
+    if (_fountainBuff.buffer !== Module.HEAPU8.buffer) {
+      _fountainBuff = new Uint8Array(Module.HEAPU8.buffer, _fountainBuff.byteOffset, _fountainBuff.byteLength);
+    }
+    return _fountainBuff;
+  }
+
   // public interface
   return {
     allocate: function () {
@@ -22,10 +29,11 @@ var Sink = function () {
       if (buff.length == 0) { // sanity check
         return;
       }
-      _fountainBuff.set(buff);
+      const fountBuff = fountain_buff();
+      fountBuff.set(buff);
 
-      console.log('sink decode ' + _fountainBuff); //TODO: base64?
-      var res = Module._cimbard_fountain_decode(_fountainBuff.byteOffset, buff.length);
+      console.log('sink decode ' + fountBuff); //TODO: base64?
+      var res = Module._cimbard_fountain_decode(fountBuff.byteOffset, buff.length);
       console.log("on decode got res " + res);
 
       const report = Sink.get_report();

--- a/web/zstd.js
+++ b/web/zstd.js
@@ -2,16 +2,6 @@ var Zstd = function () {
 
   var _decompBuff = undefined;
 
-  function _downloadHelper(name, bloburl) {
-    var aaa = document.createElement('a');
-    aaa.href = bloburl;
-    aaa.download = name;
-    document.body.appendChild(aaa);
-    aaa.style = 'display: none';
-    aaa.click();
-    aaa.remove();
-  }
-
   function getDecompressReader(id) {
     // allocate buffer once. We'll reuse it,
     // and slice() to copy to the local (non-wasm) heap
@@ -39,6 +29,7 @@ var Zstd = function () {
     });
     return readstream;
   }
+
 
   async function saveViaStreaming(readstream, filename) {
     // afaik there's no way to get the save file picker to activate
@@ -84,8 +75,15 @@ var Zstd = function () {
     // helper
     download_blob: function (name, blob) {
       var bloburl = window.URL.createObjectURL(blob);
-      _downloadHelper(name, bloburl);
+      var aaa = document.createElement('a');
+      aaa.href = bloburl;
+      aaa.download = name;
+      document.body.appendChild(aaa);
+      aaa.style = 'display: none';
+      aaa.click();
+
       setTimeout(function () {
+        aaa.remove();
         return window.URL.revokeObjectURL(bloburl);
       }, 1000);
     },


### PR DESCRIPTION
2 things:

1. for the web decoder, the "crosshairs" now move to the edge of the camera frame (on the smallest dimension), while also matching the aspect ratio of the detected mode. (e.g. B == 1:1, Bm == 1.4)
   * this means you can rely on them (somewhat) for positioning the barcode inside the frame. It's still not perfect, but it's better.
2. fixed a bug in the encoder and decoder around buffer reuse. Caching a `Uint8Array(Module.HEAPU8.buffer, ...)` is apparently malpractice (the browser might move the buffer?), and this probably led to a nonzero amount of mysterious crashes in the past (and future: until the next release :upside_down_face: ). The fix (or: *a* fix...) is to repair the cached buffer object on reuse.