### PR TITLE
Inlining/flatten hints for mobile (android) performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ if (MSVC)
     add_compile_options(/FI "iso646.h")
 endif()
 
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	set(CMAKE_INSTALL_PREFIX "${libcimbar_SOURCE_DIR}/dist" CACHE PATH "..." FORCE)
 endif()

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -6,6 +6,7 @@
 #include "Config.h"
 #include "image_hash/hamming_distance.h"
 #include "serialize/format.h"
+#include "util/compiler_constants.h"
 
 #include <algorithm>
 #include <iostream>
@@ -138,7 +139,7 @@ unsigned CimbDecoder::decode_symbol(const cv::Mat& cell, unsigned& drift_offset,
 	return get_best_symbol(results, drift_offset, best_distance, cooldown);
 }
 
-unsigned CimbDecoder::decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown) const
+CIMBAR_FLATTEN unsigned CimbDecoder::decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown) const
 {
 	int checkRule = cooldown == 0xFE? image_hash::ahash_result<cimbar::Config::cell_size()>::ALL : image_hash::ahash_result<cimbar::Config::cell_size()>::FAST;
 	image_hash::ahash_result<cimbar::Config::cell_size()> results = image_hash::fuzzy_ahash<cimbar::Config::cell_size()>(cell, checkRule);
@@ -207,7 +208,7 @@ std::tuple<uchar,uchar,uchar> CimbDecoder::avg_color(const Cell& color_cell) con
 	return center.mean_rgb();
 }
 
-unsigned CimbDecoder::decode_color(const Cell& color_cell, unsigned color_mode) const
+CIMBAR_FLATTEN unsigned CimbDecoder::decode_color(const Cell& color_cell, unsigned color_mode) const
 {
 	if (_numColors <= 1)
 		return 0;

--- a/src/lib/cimb_translator/CimbDecoder.h
+++ b/src/lib/cimb_translator/CimbDecoder.h
@@ -6,6 +6,7 @@
 #include "chromatic_adaptation/color_correction.h"
 #include "image_hash/ahash_result.h"
 #include "image_hash/average_hash.h"
+#include "util/compiler_constants.h"
 #include <opencv2/opencv.hpp>
 #include <cstdint>
 #include <string>
@@ -20,12 +21,12 @@ public:
 
 	unsigned get_best_symbol(image_hash::ahash_result<cimbar::Config::cell_size()>& results, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 	unsigned decode_symbol(const cv::Mat& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
-	unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
+	CIMBAR_FLATTEN unsigned decode_symbol(const bitmatrix& cell, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown=0xFF) const;
 
 	std::tuple<uchar,uchar,uchar> get_color(int i, unsigned color_mode) const;
 	std::tuple<uchar,uchar,uchar> avg_color(const Cell& color_cell) const;
 	unsigned get_best_color(float r, float g, float b, unsigned color_mode) const;
-	unsigned decode_color(const Cell& cell, unsigned color_mode) const;
+	CIMBAR_FLATTEN unsigned decode_color(const Cell& cell, unsigned color_mode) const;
 
 	bool expects_binary_threshold() const;
 	unsigned symbol_bits() const;

--- a/src/lib/cimb_translator/CimbReader.cpp
+++ b/src/lib/cimb_translator/CimbReader.cpp
@@ -130,13 +130,13 @@ CimbReader::CimbReader(const cv::UMat& img, CimbDecoder& decoder, unsigned color
 {
 }
 
-unsigned CimbReader::read_color(const PositionData& pos) const
+CIMBAR_ALWAYS_INLINE unsigned CimbReader::read_color(const PositionData& pos) const
 {
 	Cell color_cell(_image, pos.x, pos.y, Config::cell_size(), Config::cell_size());
 	return _decoder.decode_color(color_cell, _colorMode);
 }
 
-unsigned CimbReader::read(PositionData& pos)
+CIMBAR_ALWAYS_INLINE unsigned CimbReader::read(PositionData& pos)
 {
 	if (done())
 		return 0;

--- a/src/lib/cimb_translator/CimbReader.h
+++ b/src/lib/cimb_translator/CimbReader.h
@@ -7,6 +7,7 @@
 
 #include "bit_file/bitbuffer.h"
 #include "fountain/FountainMetadata.h"
+#include "util/compiler_constants.h"
 #include <opencv2/opencv.hpp>
 
 class CimbReader
@@ -15,8 +16,8 @@ public:
 	CimbReader(const cv::Mat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen=false, int color_correction=2);
 	CimbReader(const cv::UMat& img, CimbDecoder& decoder, unsigned color_mode, bool needs_sharpen=false, int color_correction=2);
 
-	unsigned read(PositionData& pos);
-	unsigned read_color(const PositionData& pos) const;
+	CIMBAR_ALWAYS_INLINE unsigned read(PositionData& pos);
+	CIMBAR_ALWAYS_INLINE unsigned read_color(const PositionData& pos) const;
 	bool done() const;
 
 	void init_ccm(unsigned color_bits, unsigned interleave_blocks, unsigned interleave_partitions, unsigned fountain_blocks);

--- a/src/lib/cimb_translator/test/CimbReaderTest.cpp
+++ b/src/lib/cimb_translator/test/CimbReaderTest.cpp
@@ -25,6 +25,11 @@ namespace {
 	public:
 		using CimbDecoder::CimbDecoder;
 		using CimbDecoder::internal_ccm;
+
+		~TestableCimbDecoder()
+		{
+			internal_ccm() = color_correction();
+		}
 	};
 }
 #include "serialize/str_join.h"

--- a/src/lib/extractor/Scanner.h
+++ b/src/lib/extractor/Scanner.h
@@ -5,6 +5,7 @@
 #include "Corners.h"
 #include "Point.h"
 #include "ScanState.h"
+#include "util/compiler_constants.h"
 
 #include <opencv2/opencv.hpp>
 #include <functional>
@@ -47,16 +48,16 @@ public: // other interesting methods
 	static bool sort_top_to_bottom(std::vector<Anchor>& anchors);
 
 	template <typename SCANTYPE>
-	void t1_scan_rows(std::function<void(const Anchor&)> fun, int skip=-1, int y=-1, int yend=-1, int xstart=-1, int xend=-1) const;
+	CIMBAR_FLATTEN void t1_scan_rows(std::function<void(const Anchor&)> fun, int skip=-1, int y=-1, int yend=-1, int xstart=-1, int xend=-1) const;
 
 	template <typename SCANTYPE>
-	void t2_scan_column(const Anchor& hint, std::function<void(const Anchor&)> fun) const;
+	CIMBAR_FLATTEN void t2_scan_column(const Anchor& hint, std::function<void(const Anchor&)> fun) const;
 
 	template <typename SCANTYPE>
-	void t3_scan_diagonal(const Anchor& hint, std::function<void(const Anchor&)> funs) const;
+	CIMBAR_FLATTEN void t3_scan_diagonal(const Anchor& hint, std::function<void(const Anchor&)> funs) const;
 
 	template <typename SCANTYPE>
-	void t4_confirm_scan(Anchor hint, bool merge_confirms, std::function<void(const Anchor&)> fun) const;
+	CIMBAR_FLATTEN void t4_confirm_scan(Anchor hint, bool merge_confirms, std::function<void(const Anchor&)> fun) const;
 
 	unsigned scan_primary(std::vector<Anchor>& candidates);
 	bool add_bottom_right_corner(std::vector<Anchor>& anchors, unsigned cutoff);
@@ -274,7 +275,7 @@ inline bool Scanner::scan_diagonal(std::vector<Anchor>& points, int xstart, int 
 }
 
 template <typename SCANTYPE>
-inline void Scanner::t1_scan_rows(std::function<void(const Anchor&)> fun, int skip, int y, int yend, int xstart, int xend) const
+CIMBAR_FLATTEN inline void Scanner::t1_scan_rows(std::function<void(const Anchor&)> fun, int skip, int y, int yend, int xstart, int xend) const
 {
 	if (skip <= 0)
 		skip = _skip;
@@ -292,7 +293,7 @@ inline void Scanner::t1_scan_rows(std::function<void(const Anchor&)> fun, int sk
 }
 
 template <typename SCANTYPE>
-inline void Scanner::t2_scan_column(const Anchor& hint, std::function<void(const Anchor&)> fun) const
+CIMBAR_FLATTEN inline void Scanner::t2_scan_column(const Anchor& hint, std::function<void(const Anchor&)> fun) const
 {
 	std::vector<Anchor> points;
 	int ystart = hint.y() - (3 * hint.xrange());
@@ -304,7 +305,7 @@ inline void Scanner::t2_scan_column(const Anchor& hint, std::function<void(const
 }
 
 template <typename SCANTYPE>
-inline void Scanner::t3_scan_diagonal(const Anchor& hint, std::function<void(const Anchor&)> fun) const
+CIMBAR_FLATTEN inline void Scanner::t3_scan_diagonal(const Anchor& hint, std::function<void(const Anchor&)> fun) const
 {
 	std::vector<Anchor> confirms;
 	int xstart = hint.xavg() - (2 * hint.yrange());
@@ -329,7 +330,7 @@ inline void Scanner::t3_scan_diagonal(const Anchor& hint, std::function<void(con
 }
 
 template <typename SCANTYPE>
-inline void Scanner::t4_confirm_scan(Anchor hint, bool merge_confirms, std::function<void(const Anchor&)> fun) const
+CIMBAR_FLATTEN inline void Scanner::t4_confirm_scan(Anchor hint, bool merge_confirms, std::function<void(const Anchor&)> fun) const
 {
 	// because we have a lot of weird crap going on in the center of the image,
 	// do one more scan of our (theoretical) anchor points.

--- a/src/lib/image_hash/average_hash.h
+++ b/src/lib/image_hash/average_hash.h
@@ -5,6 +5,7 @@
 #include "bit_extractor.h"
 #include "bit_file/bitmatrix.h"
 #include "cimb_translator/Cell.h"
+#include "util/compiler_constants.h"
 
 #include "intx/intx.hpp"
 #include <opencv2/opencv.hpp>
@@ -60,7 +61,7 @@ namespace image_hash
 	}
 
 	template <unsigned CELLSIZE>
-	inline ahash_result<CELLSIZE> fuzzy_ahash(const bitmatrix& img, unsigned mode=ahash_result<CELLSIZE>::ALL)
+	CIMBAR_ALWAYS_INLINE inline ahash_result<CELLSIZE> fuzzy_ahash(const bitmatrix& img, unsigned mode=ahash_result<CELLSIZE>::ALL)
 	{
 		const unsigned readlen = CELLSIZE+2;
 		intx::uint128 res(0);

--- a/src/lib/image_hash/bit_extractor.h
+++ b/src/lib/image_hash/bit_extractor.h
@@ -33,13 +33,13 @@ public:
 	{}
 
 	template<typename... T>
-	uint64_t extract()
+	constexpr uint64_t extract()
 	{
 		return 0;
 	}
 
 	template<typename... T>
-	uint64_t extract(unsigned bit_offset, const T&... t)
+	constexpr uint64_t extract(unsigned bit_offset, const T&... t)
 	{
 		constexpr auto byte_offset = sizeof...(T);
 

--- a/src/lib/image_hash/hamming_distance.h
+++ b/src/lib/image_hash/hamming_distance.h
@@ -6,7 +6,7 @@
 namespace image_hash
 {
 	template <typename Integer>
-	inline unsigned hamming_distance(Integer a, Integer b)
+	inline constexpr unsigned hamming_distance(Integer a, Integer b)
 	{
 		return popcnt64(a xor b);
 	}

--- a/src/lib/util/compiler_constants.h
+++ b/src/lib/util/compiler_constants.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#if defined(__clang__) || defined(__GNUC__)
+    #define CIMBAR_ALWAYS_INLINE __attribute__((always_inline))
+    #define CIMBAR_FLATTEN       __attribute__((flatten))
+#else
+    #define CIMBAR_ALWAYS_INLINE
+    #define CIMBAR_FLATTEN
+#endif
+

--- a/src/lib/util/compiler_constants.h
+++ b/src/lib/util/compiler_constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__clang__)
     #define CIMBAR_ALWAYS_INLINE __attribute__((always_inline))
     #define CIMBAR_FLATTEN       __attribute__((flatten))
 #else


### PR DESCRIPTION
The past approach was to use a blunt hammer and have the android app pass a top level `-mllvm -inline-threshold=$BIGNUMBER` flag to clang, then pray the compiler would do the right thing. It worked surprisingly well. Unfortunately not so much for recent clang releases (android NDK 27+), so I had to track down where flatten/inline actually gives us some benefit.

This seems to work ok. CFC will still use the inline-threshold flag, but it can do it more selectively.

note: the flatten/inline macros are *only* defined for clang at present (GCC has slightly different rules), and the one in CimbReader requires LTO to be enabled.