### PR TITLE
docs(README): add Community Tools section linking cimbar-bigfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can also encode a file using [cimbar.org](https://cimbar.org), or the latest
 
 ## Community Tools
 
-* [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — A pure-frontend wrapper that splits larger files into parallel `encode_id` streams with a `manifest.json` for reassembly, lifting the 33MB single-file cap without any protocol changes.
+* [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — A pure-frontend wrapper that splits files into multiple parallel `encode_id` streams (10–15 MB chunks per stream, well below the single-stream wirehair capacity ceiling) and ships a `manifest.json` for SHA256-verified reassembly. No changes to libcimbar or cfc required.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can also encode a file using [cimbar.org](https://cimbar.org), or the latest
 
 ## Community Tools
 
-* [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — A pure-frontend wrapper that splits files into multiple parallel `encode_id` streams (10–15 MB chunks per stream, well below the single-stream wirehair capacity ceiling) and ships a `manifest.json` for SHA256-verified reassembly. No changes to libcimbar or cfc required.
+* [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — A pure-frontend wrapper that splits files into multiple parallel `encode_id` streams (10–15 MB chunks per stream), and ships a `manifest.json` for SHA256-verified reassembly. Supports 100+ MB files. No changes to libcimbar or cfc required.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ You can also encode a file using [cimbar.org](https://cimbar.org), or the latest
 
 [TODO](TODO.md)
 
+## Community Tools
+
+* [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — A pure-frontend wrapper that splits larger files into parallel `encode_id` streams with a `manifest.json` for reassembly, lifting the 33MB single-file cap without any protocol changes.
+
 ## Inspiration
 
 * https://github.com/JohannesBuchner/imagehash/


### PR DESCRIPTION
Per discussion in #163.

Closes #163.

Adds a new "Community Tools" section to `README.md` with a single one-line entry linking to [cimbar-bigfile](https://github.com/xPeiPeix/cimbar-bigfile) — a pure-frontend wrapper that splits files into multiple parallel `encode_id` streams (10–15 MB chunks per stream, well below the single-stream wirehair capacity ceiling) and ships a `manifest.json` for SHA256-verified reassembly. No changes to libcimbar or cfc required.

**Placement**: between "Room for improvement/next steps" and "Inspiration", since the tool is a natural extension of the TODO note about splitting larger files.

Happy to adjust placement, wording, or formatting per your preference.