### PR TITLE
Fix compiler complaints, clean up GLSL-adjacent code, user newer emsdk, minor API change

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get openCV
         run: |
-          git clone --recurse-submodules --depth 1 --branch 4.11.0 https://github.com/opencv/opencv.git opencv4
+          git clone --recurse-submodules --depth 1 --branch 4.12.0 https://github.com/opencv/opencv.git opencv4
 
       - name: Get npm deps
         run: ls -l web/
@@ -39,7 +39,7 @@ jobs:
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: emscripten/emsdk:3.1.69
+          image: emscripten/emsdk:5.0.0
           options: -v ${{ github.workspace }}:/usr/src/app
           shell: bash
           run: |

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -52,13 +52,14 @@ endif()
 set (LINK_WASM_EXPORTED_FUNCTIONS
 	"_malloc"
 	, "_free"
+	, "_cimbare_init_window"
+	, "_cimbare_rotate_window"
 	, "_cimbare_render"
 	, "_cimbare_next_frame"
 	, "_cimbare_init_encode"
 	, "_cimbare_encode"
 	, "_cimbare_encode_bufsize"
 	, "_cimbare_configure"
-	, "_cimbare_rotate_window"
 	, "_cimbare_get_aspect_ratio"
 )
 

--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -30,7 +30,12 @@ extern "C" {
 
 int cimbare_init_window(int width, int height)
 {
-	// must be divisible by 4???
+	if (width <= 0)
+		width = cimbar::Config::image_size_x() + 16;
+	if (height <= 0)
+		height = cimbar::Config::image_size_y() + 16;
+
+	// GL says must be divisible by 4???
 	if (width % 4 != 0)
 		width += (4 - width % 4);
 	if (height % 4 != 0)
@@ -194,16 +199,8 @@ int cimbare_encode(const unsigned char* buffer, unsigned size)
 
 int cimbare_configure(int mode_val, int compression)
 {
-	cimbar::Config::update(mode_val);
 	if (compression < 0 or compression > 22)
 		compression = cimbar::Config::compression_level();
-
-	// make sure we've initialized
-	int window_size_x = cimbar::Config::image_size_x() + 16;
-	int window_size_y = cimbar::Config::image_size_y() + 16;
-	int initRes = cimbare_init_window(window_size_x, window_size_y);
-	if (initRes < 0)
-		return initRes;
 
 	// check if we need to refresh the stream
 	bool refresh = (mode_val != _modeVal or compression != _compressionLevel);
@@ -214,19 +211,29 @@ int cimbare_configure(int mode_val, int compression)
 		_compressionLevel = compression;
 		cimbar::Config::update(_modeVal);
 
+		// make sure the window is sized to the correct dimensions
+		if (_window)
+		{
+			int initRes = cimbare_init_window(0, 0);
+			if (initRes < 0)
+				return initRes;
+		}
+
 		// try to refresh the stream
-		if (_window and _fes)
+		if (_fes)
 		{
 			unsigned buff_size_new = cimbar::Config::fountain_chunk_size();
 			if (!_fes->restart_and_resize_buffer(buff_size_new))
 			{
 				// if the data is too small, we should throw out _fes -- and clear the canvas.
 				_fes = nullptr;
-				_window->clear();
+				if (_window)
+					_window->clear();
 				_next.reset();
 			}
 			_frameCount = 0;
-			_window->shake(0);
+			if (_window)
+				_window->shake(0);
 		}
 	}
 	return 0;

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -70,7 +70,10 @@ public:
 
 	bool load(const cv::Mat& img)
 	{
-		cimbar::mat_to_gl::load_gl_texture(_texid, img);
+		if (img.cols <= 0 or img.rows <= 0)
+			return false;
+		cimbar::mat_to_gl::load_gl_texture(_texid, img, _texdims);
+		_texdims = {static_cast<unsigned>(img.cols), static_cast<unsigned>(img.rows)};
 		return true;
 	}
 
@@ -178,6 +181,7 @@ protected:
 
 protected:
 	GLuint _texid;
+	vec_xy _texdims;
 	std::shared_ptr<cimbar::gl_program> _p;
 	std::array<GLuint, 3> _vbo;
 	GLuint _vao;

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -3,6 +3,7 @@
 
 #include "gl_program.h"
 #include "gl_shader.h"
+#include "mat_to_gl.h"
 #include "util/loop_iterator.h"
 
 #include <GLES3/gl3.h>
@@ -50,8 +51,15 @@ public:
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{
+		glGenTextures(1, &_texid);
 		glGenBuffers(3, _vbo.data());
 		glGenVertexArrays(1, &_vao);
+	}
+
+	~gl_2d_display()
+	{
+		if (_texid)
+			glDeleteTextures(1, &_texid);
 	}
 
 	void clear()
@@ -60,7 +68,13 @@ public:
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	}
 
-	void draw(GLuint texture)
+	bool load(const cv::Mat& img)
+	{
+		cimbar::mat_to_gl::load_gl_texture(_texid, img);
+		return true;
+	}
+
+	void draw()
 	{
 		GLuint prog = program();
 		glUseProgram(prog);
@@ -78,7 +92,7 @@ public:
 		// Bind to texture
 		GLuint textureUniform = glGetUniformLocation(prog, "tex");
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, texture);
+		glBindTexture(GL_TEXTURE_2D, _texid);
 		glUniform1i(textureUniform, 0);
 
 		// pass in rotation matrix
@@ -163,6 +177,7 @@ protected:
 	}
 
 protected:
+	GLuint _texid;
 	std::shared_ptr<cimbar::gl_program> _p;
 	std::array<GLuint, 3> _vbo;
 	GLuint _vao;

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -12,6 +12,77 @@
 
 namespace cimbar {
 
+class gl_2d_display_program
+{
+protected:
+	static constexpr const char* VERTEX_SHADER_SRC = R"(#version 300 es
+	uniform mat2 rot;
+	uniform vec2 tform;
+	in vec4 vert;
+	out vec2 texCoord;
+	void main() {
+	   gl_Position = vec4(vert.x, vert.y, 0.0f, 1.0f);
+	   vec2 ori = vec2(vert.x, vert.y);
+	   ori *= rot;
+	   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / 2.0;
+	   texCoord -= tform;
+	})";
+
+	static constexpr const char* FRAGMENT_SHADER_SRC = R"(#version 300 es
+	precision mediump float;
+	uniform sampler2D tex;
+	in vec2 texCoord;
+	out vec4 finalColor;
+	void main() {
+	   finalColor = texture(tex, texCoord);
+	})";
+
+public:
+	gl_2d_display_program()
+	{
+		GLuint vertexShader = cimbar::gl_shader(GL_VERTEX_SHADER, VERTEX_SHADER_SRC);
+		GLuint fragmentShader = cimbar::gl_shader(GL_FRAGMENT_SHADER, FRAGMENT_SHADER_SRC);
+
+		_p = std::make_unique<cimbar::gl_program>(
+			vertexShader, fragmentShader, "vert"
+		);
+	}
+
+	GLuint id() const
+	{
+		if (!_p)
+			return 0;
+		return (GLuint)*_p;
+	}
+
+	GLint uniform_tex()
+	{
+		if (_texLoc < 0 and id() > 0)
+			_texLoc = glGetUniformLocation(id(), "tex");
+		return _texLoc;
+	}
+
+	GLint uniform_rot()
+	{
+		if (_rotLoc < 0 and id() > 0)
+			_rotLoc = glGetUniformLocation(id(), "rot");
+		return _rotLoc;
+	}
+
+	GLint uniform_tform()
+	{
+		if (_tformLoc < 0 and id() > 0)
+			_tformLoc = glGetUniformLocation(id(), "tform");
+		return _tformLoc;
+	}
+
+protected:
+	std::unique_ptr<cimbar::gl_program> _p;
+	GLint  _texLoc = -1;
+	GLint  _rotLoc = -1;
+	GLint  _tformLoc = -1;
+};
+
 class gl_2d_display
 {
 protected:
@@ -46,20 +117,26 @@ protected:
 
 public:
 	gl_2d_display(float dim)
-	    : _p(create())
-	    , _shakePos(computeShakePos(dim))
+	    : _shakePos(computeShakePos(dim))
 	    , _shake(_shakePos)
 	    , _rotation(ROTATIONS)
 	{
-		glGenTextures(1, &_texid);
-		glGenBuffers(3, _vbo.data());
-		glGenVertexArrays(1, &_vao);
+		init();
 	}
 
 	~gl_2d_display()
 	{
 		if (_texid)
 			glDeleteTextures(1, &_texid);
+		if (_vbo)
+			glDeleteBuffers(1, &_vbo);
+		if (_vao)
+			glDeleteVertexArrays(1, &_vao);
+	}
+
+	bool good() const
+	{
+		return _p.id() != 0;
 	}
 
 	void clear()
@@ -79,51 +156,34 @@ public:
 
 	void draw()
 	{
-		GLuint prog = program();
-		glUseProgram(prog);
+		if (!good())
+			return;
 
-		// Setup VBO
-		glBindBuffer(GL_ARRAY_BUFFER, _vbo[_i]);
-		glBufferData(GL_ARRAY_BUFFER, 6 * 3 * sizeof(GLfloat), PLANE, GL_STATIC_DRAW);
+		glUseProgram(_p.id());
 
-		// Setup VAO
-		GLint vertexPositionAttribute = glGetAttribLocation(prog, "vert");
 		glBindVertexArray(_vao);
-		glEnableVertexAttribArray(vertexPositionAttribute);
-		glVertexAttribPointer(vertexPositionAttribute, 3, GL_FLOAT, GL_FALSE, 0, 0);
 
-		// Bind to texture
-		GLuint textureUniform = glGetUniformLocation(prog, "tex");
+		// bind texture
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, _texid);
-		glUniform1i(textureUniform, 0);
+		glUniform1i(_p.uniform_tex(), 0);
 
 		// pass in rotation matrix
-		GLuint rotateUniform = glGetUniformLocation(prog, "rot");
 		std::array<GLfloat, 4> rot = *_rotation;
-		glUniformMatrix2fv(rotateUniform, 1, false, rot.data());
+		glUniformMatrix2fv(_p.uniform_rot(), 1, false, rot.data());
 
 		// pass in transform vector
-		GLuint transformUniform = glGetUniformLocation(prog, "tform");
 		std::pair<GLfloat, GLfloat> tform = *_shake;
-		glUniform2f(transformUniform, tform.first, tform.second);
+		glUniform2f(_p.uniform_tform(), tform.first, tform.second);
 
 		// Draw
 		glDrawArrays(GL_TRIANGLES, 0, 6);
 
 		// Unbind
 		glBindTexture(GL_TEXTURE_2D, 0);
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glBindVertexArray(0);
 
-		++_i;
-		if (_i >= 3)
-			_i = 0;
-	}
-
-	GLuint program() const
-	{
-		return *_p;
+		glUseProgram(0);
 	}
 
 	void rotate(unsigned i=1)
@@ -143,49 +203,32 @@ public:
 	}
 
 protected:
-	static std::shared_ptr<cimbar::gl_program> create()
+	void init()
 	{
-		/* rotations
-		 *
-		 * vec2 br = vec2(1.0f + vert.x, 1.0f - vert.y); // default
-		 * vec2 bl = vec2(1.0f - vert.y, 1.0f - vert.x);
-		 * vec2 tl = vec2(1.0f - vert.x, 1.0f + vert.y);
-		 * vec2 tr = vec2(1.0f + vert.y, 1.0f + vert.x);
-		*/
-		static const std::string VERTEX_SHADER_SRC = R"(#version 300 es
-		uniform mat2 rot;
-		uniform vec2 tform;
-		in vec4 vert;
-		out vec2 texCoord;
-		void main() {
-		   gl_Position = vec4(vert.x, vert.y, 0.0f, 1.0f);
-		   vec2 ori = vec2(vert.x, vert.y);
-		   ori *= rot;
-		   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / 2.0;
-		   texCoord -= tform;
-		})";
+		glGenTextures(1, &_texid);
+		glGenBuffers(1, &_vbo);
+		glGenVertexArrays(1, &_vao);
 
-		static const std::string FRAGMENT_SHADER_SRC = R"(#version 300 es
-		precision mediump float;
-		uniform sampler2D tex;
-		in vec2 texCoord;
-		out vec4 finalColor;
-		void main() {
-		   finalColor = texture(tex, texCoord);
-		})";
+		// Setup VBO
+		glBindBuffer(GL_ARRAY_BUFFER, _vbo);
+		glBufferData(GL_ARRAY_BUFFER, 6 * 3 * sizeof(GLfloat), PLANE, GL_STATIC_DRAW);
 
-		GLuint vertexShader = cimbar::gl_shader(GL_VERTEX_SHADER, VERTEX_SHADER_SRC);
-		GLuint fragmentShader = cimbar::gl_shader(GL_FRAGMENT_SHADER, FRAGMENT_SHADER_SRC);
-		return std::make_shared<cimbar::gl_program>(vertexShader, fragmentShader, "vert");
+		// Setup VAO
+		GLint vertexPositionAttribute = glGetAttribLocation(_p.id(), "vert");
+		glBindVertexArray(_vao);
+		glEnableVertexAttribArray(vertexPositionAttribute);
+		glVertexAttribPointer(vertexPositionAttribute, 3, GL_FLOAT, GL_FALSE, 0, 0);
+
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		glBindVertexArray(0);
 	}
 
 protected:
+	gl_2d_display_program _p;
 	GLuint _texid;
 	vec_xy _texdims;
-	std::shared_ptr<cimbar::gl_program> _p;
-	std::array<GLuint, 3> _vbo;
+	GLuint _vbo;
 	GLuint _vao;
-	unsigned _i = 0;
 
 	std::array<std::pair<GLfloat, GLfloat>, 4> _shakePos;
 	loop_iterator<decltype(_shakePos)> _shake;

--- a/src/lib/gui/gl_program.h
+++ b/src/lib/gui/gl_program.h
@@ -10,9 +10,10 @@ namespace cimbar {
 class gl_program
 {
 public:
-	gl_program(GLuint vertexShader, GLuint fragmentShader, const std::string& vertextVarName)
+	template<typename... StringList>
+	gl_program(GLuint vertexShader, GLuint fragmentShader, StringList... vertextVarName)
 	{
-		_p = build(vertexShader, fragmentShader, vertextVarName);
+		_p = build(vertexShader, fragmentShader, vertextVarName...);
 	}
 
 	~gl_program()
@@ -27,12 +28,20 @@ public:
 	}
 
 protected:
-	GLuint build(GLuint vertexShader, GLuint fragmentShader, const std::string& vertextVarName)
+	template<typename... StringList>
+	GLuint build(GLuint vertexShader, GLuint fragmentShader, StringList... vertextVarName)
 	{
 		GLuint prog = glCreateProgram();
 		glAttachShader(prog, vertexShader);
 		glAttachShader(prog, fragmentShader);
-		glBindAttribLocation(prog, 0, vertextVarName.c_str());
+
+		int varI = 0;
+		(
+			[prog, &varI](const std::string& varname) {
+				glBindAttribLocation(prog, varI++, varname.c_str());
+			}
+			(vertextVarName), ...
+		);
 		glLinkProgram(prog);
 
 		GLint res;

--- a/src/lib/gui/mat_to_gl.h
+++ b/src/lib/gui/mat_to_gl.h
@@ -12,11 +12,6 @@ namespace mat_to_gl {
 	{
 		glBindTexture(GL_TEXTURE_2D, texid);
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
 		GLenum format = GL_RGB;
 		switch (mat.channels())
 		{
@@ -30,12 +25,18 @@ namespace mat_to_gl {
 				;
 		}
 
-		if (mat.cols == texdims.x and mat.rows == texdims.y)
-			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, mat.cols, mat.rows, format, GL_UNSIGNED_BYTE, mat.data);
-		else
+		if (mat.cols != texdims.x or mat.rows != texdims.y) // need init
+		{
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, mat.cols, mat.rows, 0, format, GL_UNSIGNED_BYTE, mat.data);
+		}
+		else // reuse existing memory
+			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, mat.cols, mat.rows, format, GL_UNSIGNED_BYTE, mat.data);
 
-		glBindTexture(GL_TEXTURE_2D, 0); // clean up
+		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 
 }

--- a/src/lib/gui/mat_to_gl.h
+++ b/src/lib/gui/mat_to_gl.h
@@ -1,17 +1,17 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #pragma once
 
+#include "util/vec_xy.h"
 #include <GLES3/gl3.h>
 #include <opencv2/opencv.hpp>
 
 namespace cimbar {
 namespace mat_to_gl {
 
-	inline void load_gl_texture(GLuint texid, const cv::Mat& mat)
+	inline void load_gl_texture(GLuint texid, const cv::Mat& mat, vec_xy texdims={})
 	{
 		glBindTexture(GL_TEXTURE_2D, texid);
 
-		// not sure whether we need this or not
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -29,7 +29,12 @@ namespace mat_to_gl {
 			default:
 				;
 		}
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, mat.cols, mat.rows, 0, format, GL_UNSIGNED_BYTE, mat.data);
+
+		if (mat.cols == texdims.x and mat.rows == texdims.y)
+			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, mat.cols, mat.rows, format, GL_UNSIGNED_BYTE, mat.data);
+		else
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, mat.cols, mat.rows, 0, format, GL_UNSIGNED_BYTE, mat.data);
+
 		glBindTexture(GL_TEXTURE_2D, 0); // clean up
 	}
 

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "gl_2d_display.h"
-#include "mat_to_gl.h"
 
 #include <GLFW/glfw3.h>
 #include <chrono>
@@ -42,7 +41,6 @@ public:
 		glfwSetWindowUserPointer(_w, &_ctx);
 
 		_display = std::make_shared<cimbar::gl_2d_display>(std::max(width, height));
-		glGenTextures(1, &_texid);
 		init_opengl(width, height);
 	}
 
@@ -53,8 +51,6 @@ public:
 			glfwDestroyWindow(_w);
 			_w = nullptr;
 		}
-		if (_texid)
-			glDeleteTextures(1, &_texid);
 		glfwTerminate();
 	}
 
@@ -144,8 +140,8 @@ public:
 
 		if (_display)
 		{
-			cimbar::mat_to_gl::load_gl_texture(_texid, img);
-			_display->draw(_texid);
+			_display->load(img);
+			_display->draw();
 
 			swap();
 			poll();
@@ -187,7 +183,6 @@ protected:
 protected:
 	GLFWwindow* _w = nullptr;
 	runtime_ctx _ctx;
-	GLuint _texid;
 	std::shared_ptr<cimbar::gl_2d_display> _display;
 	bool _good = true;
 };

--- a/src/third_party_lib/libcorrect/src/reed-solomon/polynomial.c
+++ b/src/third_party_lib/libcorrect/src/reed-solomon/polynomial.c
@@ -212,6 +212,9 @@ polynomial_t polynomial_init_from_roots(field_t field, unsigned int nroots, fiel
 
 polynomial_t polynomial_create_from_roots(field_t field, unsigned int nroots, field_element_t *roots) {
     polynomial_t poly = polynomial_create(nroots);
+    if (nroots == 0) // SZ3: we do a bit of defensive programming, as a treat
+        return poly;
+
     unsigned int order = nroots;
     polynomial_t l;
     l.order = 1;

--- a/src/third_party_lib/wirehair/CMakeLists.txt
+++ b/src/third_party_lib/wirehair/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(wirehair)
 
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
 set(CMAKE_CXX_STANDARD 11)
 
 set(LIB_SOURCE_FILES

--- a/web/main.js
+++ b/web/main.js
@@ -87,6 +87,7 @@ var Main = function () {
   // public interface
   return {
     init: function (canvas) {
+      Module._cimbare_init_window(0, 0);
       Main.setMode('B');
       Main.check_GL_enabled(canvas);
     },

--- a/web/test/test_send.js
+++ b/web/test/test_send.js
@@ -1,0 +1,57 @@
+QUnit.module("send");
+QUnit.config.reorder = false;
+QUnit.config.testTimeout = 10000;
+
+QUnit.testStart(async function () {
+  await WAIT_UNTIL_READY;
+});
+
+QUnit.test("encode+render", async function (assert) {
+  // put some data on the heap
+  const testData = new TextEncoder().encode(
+    "testing test testing test, unfortunately this will compress well and probably isn't the best test string\n".repeat(54)
+  );
+  const fakefile = new File([testData], "testfile.bin", { type: "application/octet-stream" });
+  Main.importFile(fakefile);
+
+  // wait for render
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const canvas = document.getElementById('canvas');
+  assert.ok(
+    canvas.width > 0 && canvas.height > 0,
+    "canvas not very big is it (" + canvas.width + "x" + canvas.height + ")"
+  );
+
+  // get the WebGL context
+  const gl = canvas.getContext('webgl2');
+  assert.ok(gl, "WebGL context is available");
+  if (!gl) {
+    return;
+  }
+
+  // sample 64x64 pixels from near the bottom left
+  const sw = Math.min(canvas.width, 64);
+  const sh = Math.min(canvas.height, 64);
+  const pixels = new Uint8Array(4 * sw * sh);
+  // we read from inside the anchors for hopefully obvious reasons
+  gl.readPixels(60, 60, sw, sh, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+  console.log("got some pixels?");
+  console.log(pixels);
+
+  // count pixels with rgb set
+  let coloredPixels = 0;
+  for (let i = 0; i < pixels.length; i += 4) {
+    if (pixels[i] > 0 || pixels[i + 1] > 0 || pixels[i + 2] > 0) {
+      coloredPixels++;
+    }
+  }
+
+  const totalPixels = sw * sh;
+  assert.ok(
+    coloredPixels > 10,
+    "canvas has " + coloredPixels + "/" + totalPixels +
+    " non-black pixels after encoding"
+  );
+});

--- a/web/test_send.html
+++ b/web/test_send.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>cimbar send js test</title>
+<link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.24.1.css">
+
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <div class="hidden">
+    <div id="status"></div>
+    <div id="dragdrop" class="dragdrop" title="Drag and drop a file" style="display: none">
+      <canvas id="canvas" class="canvas"></canvas>
+    </div>
+
+    <input style="display:none;" type="file" name="file_input" id="file_input" onchange="Main.fileInput(this);" />
+
+    <a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
+
+    <div id="nav-container" class="mode-b">
+      <div class="bg" onclick="Main.blurNav();"></div>
+      <button id="nav-button" tabindex="0" onclick="Main.clickNav();">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <div id="nav-content" tabindex="-1">
+        <span id="current-file">No file selected</span>
+        <ul>
+          <li><a class="attention" id="nav-find-file-link" href="javascript:void(0)"
+              onclick="Main.clickFileInput()">Find
+              File</a></li>
+          <hr>
+          <li class="modesel">
+            <h4>Mode</h4>
+            <a class="mode-b" href="javascript:void(0)" onclick="Main.setMode('B')">B</a>
+            <a class="mode-bm" href="javascript:void(0)" onclick="Main.setMode('Bm')">Bm</a>
+            <a class="mode-bu" href="javascript:void(0)" onclick="Main.setMode('Bu')">Bu</a>
+            <a class="mode-4c" href="javascript:void(0)" onclick="Main.setMode('4C')">4C</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript">
+    var canvas = document.getElementById('canvas');
+    canvas.getContext('webgl2', { preserveDrawingBuffer: true }); // force this immediately
+
+    let IS_READY;
+    const WAIT_UNTIL_READY = new Promise(resolve => {
+      IS_READY = resolve;
+    });
+
+    var Module = {};
+    Module.canvas = canvas;
+    Module.onRuntimeInitialized = () => {
+      Main.init(canvas);
+      Main.nextFrame();
+      IS_READY();
+    };
+  </script>
+
+  <script src="cimbar_js.js"></script>
+  <script src="main.js"></script>
+
+  <script src="https://code.jquery.com/qunit/qunit-2.24.1.js"></script>
+  <script src="test/test_send.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Miscellaneous tidying up.

* users of the `cimbare_*` apis (e.g. the web encoder) now need to call `cimbare_init_window()` + `cimbare_configure()`, rather than just the latter. Well, *if* you need a window. :slightly_smiling_face: The change should allow usage of the API without a window/GL.
* emsdk 5.0 + opencv 4.12 for the web build.
* tiny 3rd party dep changes: libcorrect (code gate) fix, wirehair (linker tweak -- not wirehair's fault)
* primordial (ok, we can call it "WIP") automated test for the sender. Very basic, but it feels better to have one.
* lots of GLSL refactoring. As I've learned more about shaders, I've learned more about how I'm using shaders wrong. This is more correct, although (having gone through the exercise now), reallocations and not caching GL uniform locations properly has basically nothing to do with the performance issues I've seen inside the PWA or android app. (tl;dr: we need to use offscreencanvas to make those work better. so stay tuned for that follow up PR...)