### PR TITLE
Add ?ww=1 param to web encoder to opt into encoding on background thread

### DIFF
--- a/src/lib/gui/CMakeLists.txt
+++ b/src/lib/gui/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 
+set (SOURCES
+	gl_2d_display.h
+	gl_program.h
+	gl_shader.h
+	mat_to_gl.h
+	window_glfw.h
+)
+
 add_library(gui INTERFACE)
 

--- a/web/index.html
+++ b/web/index.html
@@ -375,20 +375,19 @@
   <script src="main.js"></script>
 
   <script type="text/javascript">
-    var canvas = document.getElementById('canvas');
-    Main.init_ww(canvas);
-
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('./sw.js');
     }
 
-    var Module = {};
-    Module.canvas = canvas;
-    Module.onRuntimeInitialized = () => {
-      Main.init(canvas);
-    };
+    var canvas = document.getElementById('canvas');
+    if (!Main.init_ww(canvas)) {
+      var Module = {};
+      Module.canvas = canvas;
+      Module.onRuntimeInitialized = () => {
+        Main.init(canvas);
+      };
+    }
   </script>
-
   <script src="cimbar_js.js"></script>
 
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -371,11 +371,16 @@
     </div>
   </div>
 
+  <script src="send.js"></script>
+  <script src="main.js"></script>
+
   <script type="text/javascript">
+    var canvas = document.getElementById('canvas');
+    Main.init_ww(canvas);
+
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('./sw.js');
     }
-    var canvas = document.getElementById('canvas');
 
     var Module = {};
     Module.canvas = canvas;
@@ -385,8 +390,6 @@
   </script>
 
   <script src="cimbar_js.js"></script>
-  <script src="send.js"></script>
-  <script src="main.js"></script>
 
 </body>
 

--- a/web/index.html
+++ b/web/index.html
@@ -381,11 +381,11 @@
     Module.canvas = canvas;
     Module.onRuntimeInitialized = () => {
       Main.init(canvas);
-      Main.nextFrame();
     };
   </script>
 
   <script src="cimbar_js.js"></script>
+  <script src="send.js"></script>
   <script src="main.js"></script>
 
 </body>

--- a/web/main.js
+++ b/web/main.js
@@ -70,40 +70,50 @@ var Main = function () {
   return {
     init: function (canvas) {
       if (!_ww) { // no webworker, use main thread
+        console.log("main thread impl");
         Send.init_window(canvas);
         Main.setMode('B');
         Send.nextFrame();
         return;
       }
+    },
 
-      console.log("attempting ww init");
+    check_GL_enabled: function () {
+      var testCanvas = document.createElement('canvas');
+      if (!testCanvas.getContext("webgl2") && !testCanvas.getContext("webgl")) {
+        var elem = document.getElementById('dragdrop');
+        elem.classList.add("error");
+      }
     },
 
     on_ww_init: function (force_local) {
       console.log('on ww init ' + force_local);
-      var canvas = document.getElementById('canvas');
+
       if (force_local) {
         _ww = undefined;
-        Main.init(canvas);
+        window.location.hash = "#noww";
+        window.location.reload();
         return;
       }
 
-      var offscreen = canvas.transferControlToOffscreen();
-      _ww.postMessage({ fun: 'init_window', args: [offscreen] }, [offscreen]);
       Main.setMode('B');
       _ww.postMessage({ fun: 'nextFrame', args: [] });
     },
 
-    init_ww: function () {
-      if (typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
+    init_ww: function (canvas) {
+      let noww = (window.location.hash == "#noww");
+      if (noww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
         return false;
       }
-      console.log("starting ww");
+      console.log("ww impl");
+      // TODO: clone canvas maybe?
+      var offscreen = canvas.transferControlToOffscreen();
       _ww = new Worker('send-worker.js');
       _ww.onmessage = Report.handleWorkerMessage;
       _ww.onerror = function (err) {
         console.error('[send] Worker error: ', err);
       };
+      _ww.postMessage({ fun: 'init_window', args: [offscreen] }, [offscreen]);
       return true;
     },
 
@@ -123,14 +133,24 @@ var Main = function () {
     },
 
     togglePause: function (pause) {
-      Send.togglePause(pause);
+      if (_ww) {
+        _ww.postMessage({ fun: 'togglePause', args: [pause] });
+      }
+      else {
+        Send.togglePause(pause);
+      }
     },
 
     scaleCanvas: function (canvas, width, height) {
       // using ratio from current config,
       // determine optimal dimensions and rotation
       var needRotate = _idealRatio > 1 && height > width;
-      Send.rotate_window(needRotate);
+      if (_ww) {
+        _ww.postMessage({ fun: 'rotate_window', args: [needRotate] });
+      }
+      else {
+        Send.rotate_window(needRotate);
+      }
 
       var ourRatio = needRotate ? height / width : width / height;
 
@@ -263,7 +283,12 @@ var Main = function () {
       }
 
       // will trigger setAspectRatio callback
-      Send.setMode(modeVal);
+      if (_ww) {
+        _ww.postMessage({ fun: 'setMode', args: [modeVal] });
+      }
+      else {
+        Send.setMode(modeVal);
+      }
 
       var nav = document.getElementById("nav-container");
       if (modeVal == 4) {
@@ -299,7 +324,12 @@ var Main = function () {
       if (!val) {
         return;
       }
-      Send.setFPS(val);
+      if (_ww) {
+        _ww.postMessage({ fun: 'setFPS', args: [val] });
+      }
+      else {
+        Send.setFPS(val);
+      }
     },
 
     setHTML: function (id, msg) {

--- a/web/main.js
+++ b/web/main.js
@@ -1,3 +1,29 @@
+var Report = function () {
+
+  return {
+    prevent_sleep: function () {
+      setTimeout(Main.prevent_sleep, 0);
+    },
+
+    setAspectRatio: function (idealRatio) {
+      Main.setAspectRatio(idealRatio);
+    },
+
+    setActive: function (active) {
+      Main.setActive(active);
+    },
+
+    setHTML: function (id, msg) {
+      Main.setHTML(id, msg);
+    },
+
+    setTitle: function (msg) {
+      Main.setTitle(msg);
+    }
+  };
+}();
+
+
 var Main = function () {
 
   // configurable
@@ -5,17 +31,11 @@ var Main = function () {
   var _colorBalance = false;
 
   // internal
-  var _pause = 0;
   var _showStats = false;
-  var _counter = 0;
-  var _renderTime = 0;
-
-  var _lastFrame = 0; // used with _interval
   var _wakeLock = undefined;
 
   // cached
   var _idealRatio = 1;
-  var _compressBuff = undefined;
 
   function toggleFullscreen() {
     if (document.fullscreenElement) {
@@ -26,70 +46,13 @@ var Main = function () {
     }
   }
 
-  function compress_buff(chunkSize) {
-    if (_compressBuff === undefined) {
-      const dataPtr = Module._malloc(chunkSize);
-      _compressBuff = new Uint8Array(Module.HEAPU8.buffer, dataPtr, chunkSize);
-    }
-    else if (_compressBuff.buffer !== Module.HEAPU8.buffer) {
-      _compressBuff = new Uint8Array(Module.HEAPU8.buffer, _compressBuff.byteOffset, _compressBuff.byteLength);
-    }
-    return _compressBuff;
-  }
-
-  function importFile(file) {
-    let chunkSize = Module._cimbare_encode_bufsize();
-    let compBuff = compress_buff(chunkSize);
-
-    let offset = 0;
-    let reader = new FileReader();
-
-    Main.encode_init(file.name);
-
-    reader.onload = function (event) {
-      const datalen = event.target.result.byteLength;
-      if (datalen > 0) {
-        // copy to wasm buff and write
-        const uint8View = new Uint8Array(event.target.result);
-        compBuff = compress_buff(chunkSize);
-        compBuff.set(uint8View);
-        const buffView = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, datalen);
-        Main.encode_bytes(buffView);
-
-        offset += chunkSize;
-        readNext();
-      } else {
-        // Done reading file
-        console.log("Finished reading file.");
-
-        // this null call is functionally a flush()
-        // so a no-op, unless it isn't
-        const nullBuff = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, 0);
-        Main.encode_bytes(nullBuff);
-      }
-    };
-
-    function readNext() {
-      let slice = file.slice(offset, offset + chunkSize);
-      reader.readAsArrayBuffer(slice);
-    }
-
-    readNext();
-  }
-
-  function copyToWasmHeap(abuff) {
-    const dataPtr = Module._malloc(abuff.length);
-    const wasmData = new Uint8Array(Module.HEAPU8.buffer, dataPtr, abuff.length);
-    wasmData.set(abuff);
-    return wasmData;
-  }
-
   // public interface
   return {
     init: function (canvas) {
-      Module._cimbare_init_window(0, 0);
+      Send.init_window(canvas);
       Main.setMode('B');
       Main.check_GL_enabled(canvas);
+      Send.nextFrame();
     },
 
     check_GL_enabled: function (canvas) {
@@ -115,22 +78,14 @@ var Main = function () {
     },
 
     togglePause: function (pause) {
-      // pause is a cooldown. We pause to help autofocus, but we don't want to do it forever...
-      if (pause === undefined) {
-        pause = !Main.isPaused();
-      }
-      _pause = pause ? 15 : 0;
-    },
-
-    isPaused: function () {
-      return _pause > 0;
+      Send.togglePause(pause);
     },
 
     scaleCanvas: function (canvas, width, height) {
       // using ratio from current config,
       // determine optimal dimensions and rotation
       var needRotate = _idealRatio > 1 && height > width;
-      Module._cimbare_rotate_window(needRotate);
+      Send.rotate_window(needRotate);
 
       var ourRatio = needRotate ? height / width : width / height;
 
@@ -165,20 +120,6 @@ var Main = function () {
       invisible_click.style.zoom = canvas.style.zoom;
     },
 
-    encode_init: function (filename) {
-      console.log("encoding " + filename);
-      const wasmFn = copyToWasmHeap(new TextEncoder("utf-8").encode(filename));
-      try {
-        var res = Module._cimbare_init_encode(wasmFn.byteOffset, wasmFn.length, -1);
-        console.log("init_encode returned " + res);
-      } finally {
-        Module._free(wasmFn.byteOffset);
-      }
-
-      Main.setTitle(filename);
-      Main.setHTML("current-file", filename);
-    },
-
     prevent_sleep: async function () {
       if (_wakeLock) {
         return;
@@ -195,13 +136,8 @@ var Main = function () {
       requestWakeLock();
     },
 
-    encode_bytes: function (wasmData) {
-      var res = Module._cimbare_encode(wasmData.byteOffset, wasmData.length);
-      console.log("encode returned " + res);
-
-      if (res == 0) {
-        Main.setActive();
-      }
+    importFile: function (fblob) {
+      Send.importFile(fblob);
     },
 
     dragDrop: function (event) {
@@ -209,7 +145,7 @@ var Main = function () {
       console.log(event);
       const files = event.dataTransfer.files;
       if (files && files.length === 1) {
-        importFile(files[0]);
+        Main.importFile(files[0]);
       }
     },
 
@@ -247,36 +183,14 @@ var Main = function () {
       console.log("file input: " + ev);
       var file = document.getElementById('file_input').files[0];
       if (file) {
-        importFile(file);
+        Main.importFile(file);
       }
       Main.blurNav(false);
     },
 
-    nextFrame: function (timestamp) {
-      requestAnimationFrame(Main.nextFrame);
-      let elapsed = timestamp - _lastFrame;
-      if (!timestamp || elapsed < _interval) {
-        return;
-      }
-      _lastFrame = timestamp;
-
-      _counter += 1;
-      if (_pause > 0) {
-        _pause -= 1;
-      }
-      if (!Main.isPaused()) {
-        Module._cimbare_render();
-        var frameCount = Module._cimbare_next_frame(_colorBalance);
-      }
-
-      if (_showStats && frameCount) {
-        _renderTime += elapsed;
-        Main.setHTML("status", elapsed + " : " + frameCount + " : " + Math.ceil(_renderTime / frameCount));
-      }
-
-      if (!Main.isPaused() && _counter % 16 == 0) {
-        setTimeout(Main.prevent_sleep, 0);
-      }
+    setAspectRatio: function (idealRatio) {
+      _idealRatio = idealRatio;
+      Main.resize();
     },
 
     setActive: function (active) {
@@ -297,9 +211,9 @@ var Main = function () {
       else if (mode_str == "Bm") {
         modeVal = 67;
       }
-      Module._cimbare_configure(modeVal, -1);
-      _idealRatio = Module._cimbare_get_aspect_ratio();
-      Main.resize();
+
+      // will trigger setAspectRatio callback
+      Send.setMode(modeVal);
 
       var nav = document.getElementById("nav-container");
       if (modeVal == 4) {
@@ -335,8 +249,7 @@ var Main = function () {
       if (!val) {
         return;
       }
-      _interval = Math.floor(1000 / val);
-      console.log("new frame delay interval is " + _interval);
+      Send.setFPS(val);
     },
 
     setHTML: function (id, msg) {

--- a/web/main.js
+++ b/web/main.js
@@ -78,12 +78,20 @@ var Main = function () {
       }
     },
 
-    check_GL_enabled: function () {
-      var testCanvas = document.createElement('canvas');
-      if (!testCanvas.getContext("webgl2") && !testCanvas.getContext("webgl")) {
-        var elem = document.getElementById('dragdrop');
-        elem.classList.add("error");
+    init_ww: function (canvas) {
+      let noww = (window.location.hash == "#noww");
+      if (noww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
+        return false;
       }
+      console.log("ww impl");
+      var offscreen = canvas.transferControlToOffscreen();
+      _ww = new Worker('send-worker.js');
+      _ww.onmessage = Report.handleWorkerMessage;
+      _ww.onerror = function (err) {
+        console.error('[send] Worker error: ', err);
+      };
+      _ww.postMessage({ fun: 'init_window', args: [offscreen] }, [offscreen]);
+      return true;
     },
 
     on_ww_init: function (force_local) {
@@ -91,6 +99,7 @@ var Main = function () {
 
       if (force_local) {
         _ww = undefined;
+        // force refresh in main thread mode
         window.location.hash = "#noww";
         window.location.reload();
         return;
@@ -100,21 +109,13 @@ var Main = function () {
       _ww.postMessage({ fun: 'nextFrame', args: [] });
     },
 
-    init_ww: function (canvas) {
-      let noww = (window.location.hash == "#noww");
-      if (noww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
-        return false;
+
+    check_GL_enabled: function () {
+      var testCanvas = document.createElement('canvas');
+      if (!testCanvas.getContext("webgl2") && !testCanvas.getContext("webgl")) {
+        var elem = document.getElementById('dragdrop');
+        elem.classList.add("error");
       }
-      console.log("ww impl");
-      // TODO: clone canvas maybe?
-      var offscreen = canvas.transferControlToOffscreen();
-      _ww = new Worker('send-worker.js');
-      _ww.onmessage = Report.handleWorkerMessage;
-      _ww.onerror = function (err) {
-        console.error('[send] Worker error: ', err);
-      };
-      _ww.postMessage({ fun: 'init_window', args: [offscreen] }, [offscreen]);
-      return true;
     },
 
     resize: function () {

--- a/web/main.js
+++ b/web/main.js
@@ -19,6 +19,24 @@ var Report = function () {
 
     setTitle: function (msg) {
       Main.setTitle(msg);
+    },
+
+    startWasm: function (result) {
+      Main.on_ww_init(!result);
+    },
+
+    handleWorkerMessage: function (event) {
+      if (event.error) {
+        console.error('[report] error ' + event.message);
+        return;
+      }
+      const { fun, args } = event.data;
+      console.log(event.data);
+      if (typeof Report[fun] !== 'function') {
+        console.warn('[report] Unknown worker message type: ' + fun);
+        return;
+      }
+      Report[fun](...args);
     }
   };
 }();
@@ -31,6 +49,8 @@ var Main = function () {
   var _colorBalance = false;
 
   // internal
+  var _ww = undefined;
+
   var _showStats = false;
   var _wakeLock = undefined;
 
@@ -49,17 +69,42 @@ var Main = function () {
   // public interface
   return {
     init: function (canvas) {
-      Send.init_window(canvas);
-      Main.setMode('B');
-      Main.check_GL_enabled(canvas);
-      Send.nextFrame();
+      if (!_ww) { // no webworker, use main thread
+        Send.init_window(canvas);
+        Main.setMode('B');
+        Send.nextFrame();
+        return;
+      }
+
+      console.log("attempting ww init");
     },
 
-    check_GL_enabled: function (canvas) {
-      if (canvas.getContext("2d")) {
-        var elem = document.getElementById('dragdrop');
-        elem.classList.add("error");
+    on_ww_init: function (force_local) {
+      console.log('on ww init ' + force_local);
+      var canvas = document.getElementById('canvas');
+      if (force_local) {
+        _ww = undefined;
+        Main.init(canvas);
+        return;
       }
+
+      var offscreen = canvas.transferControlToOffscreen();
+      _ww.postMessage({ fun: 'init_window', args: [offscreen] }, [offscreen]);
+      Main.setMode('B');
+      _ww.postMessage({ fun: 'nextFrame', args: [] });
+    },
+
+    init_ww: function () {
+      if (typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
+        return false;
+      }
+      console.log("starting ww");
+      _ww = new Worker('send-worker.js');
+      _ww.onmessage = Report.handleWorkerMessage;
+      _ww.onerror = function (err) {
+        console.error('[send] Worker error: ', err);
+      };
+      return true;
     },
 
     resize: function () {
@@ -137,7 +182,12 @@ var Main = function () {
     },
 
     importFile: function (fblob) {
-      Send.importFile(fblob);
+      if (!_ww) {
+        Send.importFile(fblob);
+        return;
+      }
+
+      _ww.postMessage({ fun: 'importFile', args: [fblob] });
     },
 
     dragDrop: function (event) {

--- a/web/main.js
+++ b/web/main.js
@@ -80,7 +80,7 @@ var Main = function () {
 
     init_ww: function (canvas) {
       const urlParams = new URLSearchParams(window.location.search);
-      const use_ww = urlParams.get('ww');
+      const use_ww = urlParams.get('ww') || window.location.hash == "#ww=1";
       if (!use_ww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
         return false;
       }
@@ -101,6 +101,7 @@ var Main = function () {
       if (force_local) {
         _ww = undefined;
         // force refresh in main thread mode
+        window.location.hash = "";
         window.location.search = "";
         window.location.reload();
         return;

--- a/web/main.js
+++ b/web/main.js
@@ -31,7 +31,7 @@ var Report = function () {
         return;
       }
       const { fun, args } = event.data;
-      console.log(event.data);
+      //console.log(event.data);
       if (typeof Report[fun] !== 'function') {
         console.warn('[report] Unknown worker message type: ' + fun);
         return;

--- a/web/main.js
+++ b/web/main.js
@@ -79,8 +79,9 @@ var Main = function () {
     },
 
     init_ww: function (canvas) {
-      let noww = (window.location.hash == "#noww");
-      if (noww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      const use_ww = urlParams.get('ww');
+      if (!use_ww || typeof OffscreenCanvas === 'undefined' || typeof Worker === 'undefined') {
         return false;
       }
       console.log("ww impl");
@@ -100,7 +101,7 @@ var Main = function () {
       if (force_local) {
         _ww = undefined;
         // force refresh in main thread mode
-        window.location.hash = "#noww";
+        window.location.search = "";
         window.location.reload();
         return;
       }

--- a/web/pwa.json
+++ b/web/pwa.json
@@ -5,7 +5,7 @@
 	"short_name": "cimbar.org",
 	"icons": [{"src":"icon-192x192.png","sizes":"192x192","type":"image/png"},{"src":"icon-512x512.png","sizes":"512x512","type":"image/png"}],
 	"scope": "/",
-	"start_url": "index.html",
+	"start_url": "index.html?ww=1",
 	"display": "fullscreen",
 	"theme_color": "aliceblue",
 	"background_color": "black"

--- a/web/recv-sw.js
+++ b/web/recv-sw.js
@@ -36,11 +36,17 @@ self.addEventListener('fetch', function (e) {
 
 // clean old caches
 self.addEventListener('activate', function (e) {
-  e.waitUntil(function () {
+  e.waitUntil(
     caches.keys().then(function (names) {
-      for (var i in names)
-        if (names[i] != _cacheName)
-          caches.delete(names[i]);
-    });
-  });
+      return Promise.all(
+        names.map(function (cn) {
+          if (cn !== _cacheName) {
+            return caches.delete(cn);
+          }
+        })
+      );
+    }).then(function () {
+      return self.clients.claim(); 
+    })
+  );
 });

--- a/web/send-worker.js
+++ b/web/send-worker.js
@@ -74,7 +74,7 @@ var Report = function () {
     },
 
     startWasm: function (result) {
-      self.postMessage({ "fun": "setAstartWasmctive", "args": [result] });
+      self.postMessage({ "fun": "startWasm", "args": [result] });
     }
   };
 }();

--- a/web/send-worker.js
+++ b/web/send-worker.js
@@ -1,0 +1,101 @@
+'use strict';
+
+// polyfill
+if (typeof window === 'undefined') {
+  self.window = self;
+}
+
+// stubbing extra things out for emscripten's GLFW
+if (typeof window.matchMedia === 'undefined') {
+  window.matchMedia = function () {
+    return {
+      matches: false,
+      addEventListener: function () { },
+      removeEventListener: function () { },
+      addListener: function () { },        // legacy Emscripten / Safari compat
+      removeListener: function () { },
+    };
+  };
+}
+if (typeof document === 'undefined') {
+  self.document = {
+    fullscreenElement: null,
+    mozFullScreenElement: null,
+    webkitFullscreenElement: null,
+    msFullscreenElement: null,
+    getElementById: function () { return null; },
+    addEventListener: function () { },
+    removeEventListener: function () { },
+    visibilityState: 'visible',
+    hidden: false,
+  };
+}
+
+let _wasmInitialized = false;
+
+var Module = {
+  preRun: [],
+  onRuntimeInitialized: function load_done_callback() {
+    console.info("The Module is loaded and is accessible here", Module);
+    _wasmInitialized = true;
+    self.postMessage({ fun: 'startWasm', args: [true] });
+  }
+};
+
+var Report = function () {
+
+  // might be able to make this more magical...
+  return {
+    prevent_sleep: function () {
+      self.postMessage({ "fun": "prevent_sleep", "args": [] });
+    },
+
+    setAspectRatio: function (idealRatio) {
+      self.postMessage({ "fun": "setAspectRatio", "args": [idealRatio] });
+    },
+
+    setActive: function (active) {
+      self.postMessage({ "fun": "setActive", "args": [active] });
+    },
+
+    setHTML: function (id, msg) {
+      self.postMessage({ "fun": "setHTML", "args": [id, msg] });
+    },
+
+    setTitle: function (msg) {
+      self.postMessage({ "fun": "setTitle", "args": [msg] });
+    },
+
+    startWasm: function (result) {
+      self.postMessage({ "fun": "setAstartWasmctive", "args": [result] });
+    }
+  };
+}();
+
+importScripts('cimbar_js.js');
+importScripts('send.js');
+
+self.onmessage = async (event) => {
+
+  console.log("hello?");
+  if (!_wasmInitialized) {
+    console.log('we got no wasm :(');
+    self.postMessage({ fun: 'startWasm', args: [false] });
+    return;
+  }
+
+  const { fun, args } = event.data;
+  if (typeof Send[fun] !== 'function') {
+    console.warn('[send-worker] Unknown message type: ' + fun);
+    return;
+  }
+
+  console.log('got a message ' + fun);
+
+  try {
+    Send[fun](...args);
+  } catch (ex) {
+    console.log("unexpected error: " + ex);
+    self.postMessage({ error: true, message: ex });
+  }
+};

--- a/web/send-worker.js
+++ b/web/send-worker.js
@@ -38,7 +38,14 @@ var Module = {
   onRuntimeInitialized: function load_done_callback() {
     console.info("The Module is loaded and is accessible here", Module);
     _wasmInitialized = true;
-    self.postMessage({ fun: 'startWasm', args: [true] });
+    try {
+      Send.init_window(Module.canvas);
+      self.postMessage({ fun: 'startWasm', args: [true] });
+    } catch (ex) {
+      console.log("unexpected init error: " + ex);
+      self.postMessage({ fun: 'startWasm', args: [false] });
+    }
+
   }
 };
 
@@ -72,17 +79,9 @@ var Report = function () {
   };
 }();
 
-importScripts('cimbar_js.js');
 importScripts('send.js');
 
 self.onmessage = async (event) => {
-
-  console.log("hello?");
-  if (!_wasmInitialized) {
-    console.log('we got no wasm :(');
-    self.postMessage({ fun: 'startWasm', args: [false] });
-    return;
-  }
 
   const { fun, args } = event.data;
   if (typeof Send[fun] !== 'function') {
@@ -91,6 +90,18 @@ self.onmessage = async (event) => {
   }
 
   console.log('got a message ' + fun);
+
+  if (fun === 'init_window') {
+    Module.canvas = args[0];
+    importScripts('cimbar_js.js');
+    return;
+  }
+
+  if (!_wasmInitialized) {
+    console.log('we got no wasm yet :(');
+    self.postMessage({ fun: 'startWasm', args: [false] });
+    return;
+  }
 
   try {
     Send[fun](...args);

--- a/web/send.js
+++ b/web/send.js
@@ -130,7 +130,7 @@ var Send = function () {
     },
 
     nextFrame: function (timestamp) {
-      console.log("in nextFrame, is it happening?");
+      //console.log("in nextFrame, is it happening?");
       window.requestAnimationFrame(Send.nextFrame);
       let elapsed = timestamp - _lastFrame;
       if (!timestamp || elapsed < _interval) {

--- a/web/send.js
+++ b/web/send.js
@@ -1,0 +1,172 @@
+
+var Send = function () {
+  // the canvas
+  var _canvas = undefined; // set by init
+
+  // configurable
+  var _interval = 66;
+  var _colorBalance = false;
+
+  // internal
+  var _pause = 0;
+  var _showStats = false;
+  var _counter = 0;
+  var _renderTime = 0;
+
+  var _lastFrame = 0; // used with _interval
+  var _wakeLock = undefined;
+
+  // cached
+  var _idealRatio = 1;
+  var _compressBuff = undefined;
+
+  function compress_buff(chunkSize) {
+    if (_compressBuff === undefined) {
+      const dataPtr = Module._malloc(chunkSize);
+      _compressBuff = new Uint8Array(Module.HEAPU8.buffer, dataPtr, chunkSize);
+    }
+    else if (_compressBuff.buffer !== Module.HEAPU8.buffer) {
+      _compressBuff = new Uint8Array(Module.HEAPU8.buffer, _compressBuff.byteOffset, _compressBuff.byteLength);
+    }
+    return _compressBuff;
+  }
+
+  function importFile(file) {
+    let chunkSize = Module._cimbare_encode_bufsize();
+    let compBuff = compress_buff(chunkSize);
+
+    let offset = 0;
+    let reader = new FileReader();
+
+    Send.encode_init(file.name);
+
+    reader.onload = function (event) {
+      const datalen = event.target.result.byteLength;
+      if (datalen > 0) {
+        // copy to wasm buff and write
+        const uint8View = new Uint8Array(event.target.result);
+        compBuff = compress_buff(chunkSize);
+        compBuff.set(uint8View);
+        const buffView = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, datalen);
+        Send.encode_bytes(buffView);
+
+        offset += chunkSize;
+        readNext();
+      } else {
+        // Done reading file
+        console.log("Finished reading file.");
+
+        // this null call is functionally a flush()
+        // so a no-op, unless it isn't
+        const nullBuff = new Uint8Array(Module.HEAPU8.buffer, compBuff.byteOffset, 0);
+        Send.encode_bytes(nullBuff);
+      }
+    };
+
+    function readNext() {
+      let slice = file.slice(offset, offset + chunkSize);
+      reader.readAsArrayBuffer(slice);
+    }
+
+    readNext();
+  }
+
+  function copyToWasmHeap(abuff) {
+    const dataPtr = Module._malloc(abuff.length);
+    const wasmData = new Uint8Array(Module.HEAPU8.buffer, dataPtr, abuff.length);
+    wasmData.set(abuff);
+    return wasmData;
+  }
+
+  // public interface
+  return {
+    init_window: function (canvas) {
+      _canvas = canvas;
+      Module._cimbare_init_window(0, 0);
+    },
+
+    importFile: function (file) {
+      importFile(file);
+    },
+
+    togglePause: function (pause) {
+      // pause is a cooldown. We pause to help autofocus, but we don't want to do it forever...
+      if (pause === undefined) {
+        pause = !Send.isPaused();
+      }
+      _pause = pause ? 15 : 0;
+    },
+
+    isPaused: function () {
+      return _pause > 0;
+    },
+
+    rotate_window: function (needRotate) {
+      Module._cimbare_rotate_window(needRotate);
+    },
+
+    encode_init: function (filename) {
+      console.log("encoding " + filename);
+      const wasmFn = copyToWasmHeap(new TextEncoder("utf-8").encode(filename));
+      try {
+        var res = Module._cimbare_init_encode(wasmFn.byteOffset, wasmFn.length, -1);
+        console.log("init_encode returned " + res);
+      } finally {
+        Module._free(wasmFn.byteOffset);
+      }
+
+      Report.setTitle(filename);
+      Report.setHTML("current-file", filename);
+    },
+
+    encode_bytes: function (wasmData) {
+      var res = Module._cimbare_encode(wasmData.byteOffset, wasmData.length);
+      console.log("encode returned " + res);
+
+      if (res == 0) {
+        Report.setActive();
+      }
+    },
+
+    nextFrame: function (timestamp) {
+      requestAnimationFrame(Send.nextFrame);
+      let elapsed = timestamp - _lastFrame;
+      if (!timestamp || elapsed < _interval) {
+        return;
+      }
+      _lastFrame = timestamp;
+
+      _counter += 1;
+      if (_pause > 0) {
+        _pause -= 1;
+      }
+      if (!Send.isPaused()) {
+        Module._cimbare_render();
+        var frameCount = Module._cimbare_next_frame(_colorBalance);
+      }
+
+      if (_showStats && frameCount) {
+        _renderTime += elapsed;
+        Report.setHTML("status", elapsed + " : " + frameCount + " : " + Math.ceil(_renderTime / frameCount));
+      }
+
+      if (!Send.isPaused() && _counter % 16 == 0) {
+        Report.prevent_sleep();
+      }
+    },
+
+    setMode: function (mode_val) {
+      // call resize after this from Main?
+      Module._cimbare_configure(mode_val, -1);
+      Report.setAspectRatio(Module._cimbare_get_aspect_ratio());
+    },
+
+    setFPS: function (val) {
+      if (!val) {
+        return;
+      }
+      _interval = Math.floor(1000 / val);
+      console.log("new frame delay interval is " + _interval);
+    }
+  };
+}();

--- a/web/send.js
+++ b/web/send.js
@@ -1,6 +1,7 @@
 
 var Send = function () {
   // the canvas
+  var _ctx = undefined;
   var _canvas = undefined; // set by init
 
   // configurable
@@ -129,7 +130,8 @@ var Send = function () {
     },
 
     nextFrame: function (timestamp) {
-      requestAnimationFrame(Send.nextFrame);
+      console.log("in nextFrame, is it happening?");
+      window.requestAnimationFrame(Send.nextFrame);
       let elapsed = timestamp - _lastFrame;
       if (!timestamp || elapsed < _interval) {
         return;

--- a/web/sw.js
+++ b/web/sw.js
@@ -33,11 +33,17 @@ self.addEventListener('fetch', function (e) {
 
 // clean old caches
 self.addEventListener('activate', function (e) {
-  e.waitUntil(function () {
+  e.waitUntil(
     caches.keys().then(function (names) {
-      for (var i in names)
-        if (names[i] != _cacheName)
-          caches.delete(names[i]);
-    });
-  });
+      return Promise.all(
+        names.map(function (cn) {
+          if (cn !== _cacheName) {
+            return caches.delete(cn);
+          }
+        })
+      );
+    }).then(function () {
+      return self.clients.claim(); 
+    })
+  );
 });

--- a/web/sw.js
+++ b/web/sw.js
@@ -25,7 +25,7 @@ self.addEventListener('install', function (e) {
 // serve from cache
 self.addEventListener('fetch', function (e) {
   e.respondWith(
-    caches.match(e.request).then(function (response) {
+    caches.match(e.request, { ignoreSearch: true }).then(function (response) {
       return response || fetch(e.request);
     })
   );

--- a/web/test/run-in-browser.js
+++ b/web/test/run-in-browser.js
@@ -6,12 +6,18 @@ const puppeteer = require('puppeteer');
 const path = require('path');
 const QUnit = require('qunit');
 
-(async () => {
-  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] });
-  const page = await browser.newPage();
+const testPages = ['test_recv.html', 'test_send.html'];
 
-  page.on('console', msg => console.log('BROWSER CONSOLE:', msg.text()));
-  page.on('pageerror', err => console.error('PAGE ERROR:', err));
+async function runTestPage(browser, testPagePath) {
+  const page = await browser.newPage();
+  page.setDefaultNavigationTimeout(30000);
+  page.setDefaultTimeout(30000);
+
+  page.on('console', msg => console.log(`[${testPagePath}] BROWSER CONSOLE:`, msg.text()));
+  page.on('pageerror', err => console.error(`[${testPagePath}] PAGE ERROR:`, err));
+
+  let resolveStats;
+  const statsPromise = new Promise(resolve => { resolveStats = resolve; });
 
   await page.exposeFunction('onLogMe', (details) => {
     if (!details.result) {
@@ -21,23 +27,13 @@ const QUnit = require('qunit');
     }
   });
 
-  // Expose a function to capture QUnit results
   await page.exposeFunction('onQUnitDone', (stats) => {
-    if (stats.failed > 0) {
-      console.error(stats);
-      console.error(`QUnit Tests Failed: ${stats.failed} assertions failed.`);
-      process.exit(stats.failed); // nonzero is failure
-    } else {
-      console.log('All QUnit Tests Passed!');
-      process.exit(0);
-    }
+    resolveStats(stats);
   });
 
-  // Navigate to your QUnit test page
-  const testPagePath = '/test_recv.html';
   await page.goto(`http://localhost:8080/${testPagePath}`);
 
-  // Wait for QUnit to finish
+  // Hook QUnit log and done handlers inside the page
   await page.evaluate(() => {
     return new Promise(resolve => {
       QUnit.log(details => {
@@ -51,5 +47,33 @@ const QUnit = require('qunit');
     });
   });
 
+  const stats = await statsPromise;
+  await page.close();
+  return stats;
+}
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+
+  let totalFailed = 0;
+  for (const testPagePath of testPages) {
+    console.log(`Running tests: ${testPagePath}`);
+    const stats = await runTestPage(browser, testPagePath);
+    if (stats.failed > 0) {
+      console.error(`FAILED [${testPagePath}]: ${stats.failed} assertions failed.`);
+      totalFailed += stats.failed;
+    } else {
+      console.log(`PASSED [${testPagePath}]`);
+    }
+  }
+
   await browser.close();
+
+  if (totalFailed > 0) {
+    console.error(`Total QUnit failures: ${totalFailed}`);
+    process.exit(totalFailed);
+  } else {
+    console.log('All QUnit Tests Passed!');
+    process.exit(0);
+  }
 })();

--- a/web/test_send.html
+++ b/web/test_send.html
@@ -57,12 +57,12 @@
     Module.canvas = canvas;
     Module.onRuntimeInitialized = () => {
       Main.init(canvas);
-      Main.nextFrame();
       IS_READY();
     };
   </script>
 
   <script src="cimbar_js.js"></script>
+  <script src="send.js"></script>
   <script src="main.js"></script>
 
   <script src="https://code.jquery.com/qunit/qunit-2.24.1.js"></script>

--- a/web/wasmgz.sh
+++ b/web/wasmgz.sh
@@ -2,7 +2,7 @@
 # run from within web dir
 # does various renames for cache busting
 
-RENAME_FILES=$(ls cimbar_js.js cimbar_js.wasm main.js recv.js recv-worker.js zstd.js pwa*.json)
+RENAME_FILES=$(ls cimbar_js.js cimbar_js.wasm main.js send.js send-worker.js recv.js recv-worker.js zstd.js pwa*.json)
 GSUB_FILES="index.html recv.html sw.js recv-sw.js $(echo $RENAME_FILES | sed 's/cimbar_js\.wasm//g')"
 
 VERSION=${VERSION:-$(date --utc '+%Y-%m-%dT%H%M')}


### PR DESCRIPTION
On most platforms (that I've tested anyway), the encoder (+GL calls) runs fast enough that staying on the main thread is fine. (Trivia: on mobile platforms under normal circumstances, the GL calls get offloaded from the main thread automatically)

But in two specific cases we see real slowdown (can't hit 15 fps, have to downgrade to 10 or lower):
1. android PWA operating in offline mode. I don't know why there's a difference, and this probably varies by android version
2. android app webview, a.k.a. what CFC currently uses to embed the encoder.

So: if a param is supplied (either `?ww=1` in the query string, or `#ww=1` as the fragment), we spin up a webworker and hand it the canvas (via OffscreenCanvas) to run in the background.

Additionally:
* fixed a bug in our pwa caching. Oops.
* simple automated browser test for encoder JS logic. Long overdue.