### PR TITLE
relax the C api's cimbare_encode() bufize check to allow multiples of chunk size (16kb)

### DIFF
--- a/src/lib/cimbar_js/cimbar_js.cpp
+++ b/src/lib/cimbar_js/cimbar_js.cpp
@@ -178,7 +178,7 @@ int cimbare_encode(const unsigned char* buffer, unsigned size)
 		if (!_comp->write(reinterpret_cast<const char*>(buffer), size))
 			return -2;
 	}
-	if (size == cimbare_encode_bufsize())
+	if (size%cimbare_encode_bufsize() == 0 and size != 0)
 		return 1; // more to do
 
 	// otherwise, we're ready

--- a/src/lib/cimbar_js/test/cimbar_jsTest.cpp
+++ b/src/lib/cimbar_js/test/cimbar_jsTest.cpp
@@ -77,9 +77,6 @@ TEST_CASE( "cimbar_jsTest/testRoundtrip", "[unit]" )
 
 TEST_CASE( "cimbar_jsTest/testEncodeFlushNoop", "[unit]" )
 {
-	std::vector<unsigned char> decbuff;
-	decbuff.resize(cimbard_get_bufsize());
-
 	const int size = cimbare_encode_bufsize();
 	std::string contents = random_string(size);
 	std::string filename = "/tmp/foobar-c语言版.txt";
@@ -93,3 +90,19 @@ TEST_CASE( "cimbar_jsTest/testEncodeFlushNoop", "[unit]" )
 	assertEquals( -1, cimbare_encode(nullptr, 0) );
 }
 
+TEST_CASE( "cimbar_jsTest/testEncodeBufsizeMult", "[unit]" )
+{
+	// even multiple of bufsize also requires a "flush"
+	// a.k.a. you can use a multiple as your "chunk" size if you want
+	const int size = cimbare_encode_bufsize() * 8;
+	std::string contents = random_string(size);
+	std::string filename = "/tmp/foobar-c语言版.txt";
+	assertEquals( 0, cimbare_init_encode(filename.data(), filename.size(), 100) );
+	assertEquals( 1, cimbare_encode(reinterpret_cast<unsigned char*>(contents.data()), contents.size()) );
+	assertEquals( -1, cimbare_next_frame() );
+
+	assertEquals( 0, cimbare_encode(nullptr, 0) );
+	assertEquals( 1, cimbare_next_frame() );
+
+	assertEquals( -1, cimbare_encode(nullptr, 0) );
+}


### PR DESCRIPTION
There's no reason not to allow this, and it gives us more flexibility downstream (ex: maybe the caller wants to use 128k buffers instead of 16k).