### PR TITLE
cimbar send js fixes

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -101,9 +101,8 @@ var Main = function () {
       if (force_local) {
         _ww = undefined;
         // force refresh in main thread mode
-        window.location.hash = "";
-        window.location.search = "";
-        window.location.reload();
+        const cleanURL = window.location.origin + window.location.pathname;
+        window.location.replace(cleanURL);
         return;
       }
 

--- a/web/pwa.json
+++ b/web/pwa.json
@@ -2,10 +2,10 @@
 	"lang": "en",
 	"dir": "ltr",
 	"name": "cimbar.org Send",
-	"short_name": "cimbar.org",
+	"short_name": "cimbar send",
 	"icons": [{"src":"icon-192x192.png","sizes":"192x192","type":"image/png"},{"src":"icon-512x512.png","sizes":"512x512","type":"image/png"}],
 	"scope": "/",
-	"start_url": "index.html?ww=1",
+	"start_url": "/index.html?ww=1",
 	"display": "fullscreen",
 	"theme_color": "aliceblue",
 	"background_color": "black"

--- a/web/send.js
+++ b/web/send.js
@@ -33,7 +33,7 @@ var Send = function () {
   }
 
   function importFile(file) {
-    let chunkSize = Module._cimbare_encode_bufsize();
+    let chunkSize = Module._cimbare_encode_bufsize() * 16;
     let compBuff = compress_buff(chunkSize);
 
     let offset = 0;


### PR DESCRIPTION
Follow up to the (still unreleased) #171 and #172.

* fix the `force_local` redirect/fallback for the new offscreencanvas+ww impl (for android webview and PWA). Tested on an assortment of devices...
* increase the buff size to 256kb (16kb zstd chunk size * 16) for the web encoder's `importFile()` (when we loop over input file bytes). The buff size was shrunk (too) conservatively in #145 -- 256kb of contiguous memory shouldn't be too much to ask for I think. In some circumstances, e.g. when used in the webview on my older android phone, the smaller buffer creates a *very* noticeable performance hit on file load. This speeds things back up.