### PR TITLE
decompression loop fix + cleanup for decode hot path + overdue unit test for bitmatrix

### DIFF
--- a/src/lib/bit_file/CMakeLists.txt
+++ b/src/lib/bit_file/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(SOURCES
-	bitreader.h
 	bitbuffer.h
+	bitmatrix.h
+	bitreader.h
+
 )
 
 add_library(bit_file INTERFACE)

--- a/src/lib/bit_file/bitbuffer.h
+++ b/src/lib/bit_file/bitbuffer.h
@@ -1,6 +1,7 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 #pragma once
 
+#include "util/compiler_constants.h"
 #include <vector>
 
 // write bits -> buffer
@@ -16,20 +17,25 @@ public:
 		{}
 
 		template <typename UINT>
-		bool write_byte(UINT byte)
+		inline bool write_byte(UINT byte)
 		{
-			return write(byte, 8);
+			size_t pos = _pos;
+			_pos += 8;
+			if (pos % 8 != 0)
+				return _bb.write(byte, pos, 8);
+			// else
+			return _bb.write_aligned_byte(byte, pos);
 		}
 
 		template <typename UINT>
-		bool write(UINT byte, int length)
+		inline bool write(UINT byte, int length)
 		{
 			size_t pos = _pos;
 			_pos += length;
 			return _bb.write(byte, pos, length);
 		}
 
-		writer& operator<<(uint8_t byte)
+		inline writer& operator<<(uint8_t byte)
 		{
 			write_byte(byte);
 			return *this;
@@ -42,12 +48,12 @@ public:
 
 public:
 	bitbuffer(unsigned size_hint=9300)
-	    : _sizeHint(size_hint)
+		: _sizeHint(size_hint)
 	{
 		clear();
 	}
 
-	void resize(unsigned length)
+	inline void resize(unsigned length)
 	{
 		size_t requestedSize = length/8;
 		size_t size = _buffer.size();
@@ -59,7 +65,7 @@ public:
 		_buffer.resize(size, 0);
 	}
 
-	bool write(unsigned data, unsigned index, int length)
+	inline bool write(unsigned data, unsigned index, int length)
 	{
 		resize(index+length);
 
@@ -83,38 +89,49 @@ public:
 		return true;
 	}
 
-	unsigned read(unsigned index, int length) const
+	CIMBAR_ALWAYS_INLINE inline bool write_aligned_byte(uint8_t byte, unsigned index)
 	{
+		resize(index+8);
+		int byteIndex = index/8;
+		_buffer[byteIndex] = byte;
+		return true;
+	}
+
+	template <typename UINT=uint64_t>
+	CIMBAR_ALWAYS_INLINE inline UINT read(unsigned index, int length) const
+	{
+		if (length <= 0)
+			return 0;
+
 		int currentByte = index/8;
 		int currentBit = index%8;
 
-		unsigned res = 0;
-		int nextRead = std::min(length, 8-currentBit); // read this many bits
+		UINT res = 0;
 		while (length > 0)
 		{
+			int rdsz = std::min(length, 8-currentBit);
 			unsigned char bits = static_cast<unsigned char>(_buffer[currentByte]) << currentBit;
-			bits = bits >> (8-nextRead);
-			res |= bits << (length - nextRead);
+			bits = bits >> (8 - rdsz);
 
-			length -= nextRead;
-			currentBit += nextRead;
-			if (currentBit >= 8)
-				currentBit = 0;
-			currentByte += 1;
-			nextRead = std::min(length, 8-currentBit);
+			length -= rdsz;
+			currentBit = 0;
+			++currentByte;
+
+			UINT temp = bits;
+			res |= (temp << length);
 		}
 		return res;
 	}
 
 	template <typename STREAM>
-	long flush(STREAM& f)
+	inline long flush(STREAM& f)
 	{
 		f.write(buffer().data(), buffer().size());
 		clear();
 		return f.tellp();
 	}
 
-	void clear()
+	inline void clear()
 	{
 		_buffer = {0};
 		_buffer.resize(_sizeHint, 0);
@@ -125,13 +142,13 @@ public:
 		return _buffer;
 	}
 
-	void copy_to_buffer(const char* data, unsigned size)
+	inline void copy_to_buffer(const char* data, unsigned size)
 	{
 		_buffer.resize(size, 0);
 		std::copy(data, data+size, _buffer.data());
 	}
 
-	writer get_writer(size_t pos=0)
+	inline writer get_writer(size_t pos=0)
 	{
 		return writer(*this, pos);
 	}

--- a/src/lib/bit_file/test/CMakeLists.txt
+++ b/src/lib/bit_file/test/CMakeLists.txt
@@ -5,6 +5,7 @@ project(bit_file_test)
 set (SOURCES
 	test.cpp
 	bitbufferTest.cpp
+	bitmatrixTest.cpp
 	bitreaderTest.cpp
 )
 
@@ -21,3 +22,7 @@ add_executable (
 
 add_test(bit_file_test bit_file_test)
 
+target_link_libraries(bit_file_test
+
+	${OPENCV_LIBS}
+)

--- a/src/lib/bit_file/test/bitmatrixTest.cpp
+++ b/src/lib/bit_file/test/bitmatrixTest.cpp
@@ -1,0 +1,36 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+#include "TestHelpers.h"
+
+#include "bitmatrix.h"
+
+#include <opencv2/opencv.hpp>
+
+TEST_CASE( "bitmatrixTest/test_mat_to_bitbuffer", "[unit]" )
+{
+	cv::Mat symbols = TestCimbar::loadSample("b/tr_0.png");
+	assertEquals( 1024, symbols.cols );
+	assertEquals( 1024, symbols.rows );
+
+	// grayscale and threshold, to imitate the decoder process
+	cv::cvtColor(symbols, symbols, cv::COLOR_RGB2GRAY);
+	cv::adaptiveThreshold(symbols, symbols, 255, cv::ADAPTIVE_THRESH_MEAN_C, cv::THRESH_BINARY, 7, 0);
+
+	bitbuffer bb(symbols.rows * symbols.cols / 8);
+	bitmatrix::mat_to_bitbuffer(symbols, bb.get_writer());
+
+	// 62,8
+	int start = 8254;
+	assertEquals( 0xFF, bb.read(start, 8) );
+	assertEquals( 0xFE, bb.read(start+1024, 8) );
+	assertEquals( 0xFC, bb.read(start+2048, 8) );
+	assertEquals( 0xF8, bb.read(start+3072, 8) );
+	assertEquals( 0xF0, bb.read(start+4096, 8) );
+
+	bitmatrix bm(bb, 1024, 1024, 61, 7);
+	assertEquals( 0xFF, bm.get(1, 1, 8) );
+	assertEquals( 0xFE, bm.get(1, 2, 8) );
+	assertEquals( 0xFC, bm.get(1, 3, 8) );
+	assertEquals( 0xF8, bm.get(1, 4, 8) );
+	assertEquals( 0xF0, bm.get(1, 5, 8) );
+}

--- a/src/lib/cimb_translator/CimbDecoder.cpp
+++ b/src/lib/cimb_translator/CimbDecoder.cpp
@@ -100,9 +100,11 @@ bool CimbDecoder::load_tiles()
 
 unsigned CimbDecoder::get_best_symbol(image_hash::ahash_result<cimbar::Config::cell_size()>& results, unsigned& drift_offset, unsigned& best_distance, unsigned cooldown) const
 {
-	drift_offset = 0;
 	unsigned best_fit = 0;
+	drift_offset = 0;
 	best_distance = 1000;
+	cooldown = (cooldown == 4)? 0xFF : cooldown;  // don't skip the center, obvs
+
 	// ahash_result will give us either 5 or 9 candidate hashes -- depending on whether we want to ignore the corners or not.
 	// Because we're greedy (see the `return`), we will iterate out from the center
 	// 4 == center.
@@ -113,7 +115,7 @@ unsigned CimbDecoder::get_best_symbol(image_hash::ahash_result<cimbar::Config::c
 		// skip over this drift_idx if it matches cooldown
 		// we could be more clever to check for corners, but for now this is fine
 		// ~0U is "unset"
-		if (drift_idx == cooldown and drift_idx != 4) // don't skip the center, obvs
+		if (drift_idx == cooldown)
 			continue;
 		for (unsigned i = 0; i < _tileHashes.size(); ++i)
 		{

--- a/src/lib/cimb_translator/FloodDecodePositions.cpp
+++ b/src/lib/cimb_translator/FloodDecodePositions.cpp
@@ -103,12 +103,9 @@ int FloodDecodePositions::update(unsigned index, const CellDrift& drift, unsigne
 		{
 			std::array<int,4> horizon = {-1, -1, -1, -1};
 			horizon[0] = _cellFinder.right(rridx);
-			if (horizon[0] >= 0)
-				horizon[1] = _cellFinder.right(horizon[0]);
+			horizon[1] = _cellFinder.right(horizon[0]);
 			horizon[2] = _cellFinder.left(llidx);
-			if (horizon[2] >= 0)
-				horizon[3] = _cellFinder.left(horizon[2]);
-
+			horizon[3] = _cellFinder.left(horizon[2]);
 			update_adjacents(horizon, drift, error_distance, cooldown);
 		}
 
@@ -118,12 +115,9 @@ int FloodDecodePositions::update(unsigned index, const CellDrift& drift, unsigne
 		{
 			std::array<int,4> vert = {-1, -1, -1, -1};
 			vert[0] = _cellFinder.top(uuidx);
-			if (vert[0] >= 0)
-				vert[1] = _cellFinder.top(vert[0]);
+			vert[1] = _cellFinder.top(vert[0]);
 			vert[2] = _cellFinder.bottom(ddidx);
-			if (vert[2] >= 0)
-				vert[3] = _cellFinder.bottom(vert[2]);
-
+			vert[3] = _cellFinder.bottom(vert[2]);
 			update_adjacents(vert, drift, error_distance, cooldown);
 		}
 	}

--- a/src/lib/cimb_translator/LinearDecodePositions.h
+++ b/src/lib/cimb_translator/LinearDecodePositions.h
@@ -13,12 +13,14 @@ public:
 public:
 	LinearDecodePositions(cimbar::vec_xy spacing, cimbar::vec_xy dimensions, int offset, cimbar::vec_xy marker_size);
 
-	size_t count() const;
+	size_t size() const;
 	void reset();
 
 	bool done() const;
 	iter next();
 	int update(unsigned index, const CellDrift& drift, unsigned error_distance);
+
+	const CellPositions::positions_list& positions() const;
 
 protected:
 	unsigned _index;
@@ -33,9 +35,14 @@ inline LinearDecodePositions::LinearDecodePositions(cimbar::vec_xy spacing, cimb
 	reset();
 }
 
-inline size_t LinearDecodePositions::count() const
+inline size_t LinearDecodePositions::size() const
 {
 	return _positions.size();
+}
+
+inline const CellPositions::positions_list& LinearDecodePositions::positions() const
+{
+	return _positions;
 }
 
 inline void LinearDecodePositions::reset()

--- a/src/lib/compression/zstd_decompressor.h
+++ b/src/lib/compression/zstd_decompressor.h
@@ -34,6 +34,7 @@ public:
 				if (ZSTD_isError(res))
 				{
 					_lastError << " failed decompress? " << ZSTD_getErrorName(res);
+					_isError = true;
 					return false;
 				}
 
@@ -61,7 +62,7 @@ public:
 	{
 		if (!init_decompress(data, len))
 			return false;
-		while (_inBuff.size() > 0)
+		while (_inBuff.size() > 0 and good())
 			write_once();
 		return true;
 	}
@@ -91,6 +92,11 @@ public:
 		return totalBytesRead;
 	}
 
+	bool good() const
+	{
+		return !_isError and STREAM::good();
+	}
+
 	std::string last_error() const
 	{
 		return _lastError.str();
@@ -102,6 +108,7 @@ protected:
 	std::vector<char> _outBuff = std::vector<char>(ZSTD_DStreamOutSize());
 	std::string_view _inBuff;
 
+	bool _isError = false;
 	std::stringstream _lastError;
 };
 

--- a/src/lib/compression/zstd_decompressor.h
+++ b/src/lib/compression/zstd_decompressor.h
@@ -35,7 +35,7 @@ public:
 				{
 					_lastError << " failed decompress? " << ZSTD_getErrorName(res);
 					_isError = true;
-					return false;
+					return false; // we're not making progress, mayday mayday
 				}
 
 				if (output.pos > 0)
@@ -47,7 +47,7 @@ public:
 			}
 			_inBuff = std::string_view(_inBuff.data() + input.size, _inBuff.size() - input.size);
 		}
-		return false;
+		return true;
 	}
 
 	bool init_decompress(const char* data, size_t len)
@@ -62,8 +62,9 @@ public:
 	{
 		if (!init_decompress(data, len))
 			return false;
-		while (_inBuff.size() > 0 and good())
-			write_once();
+		while (_inBuff.size() > 0)
+			if (!write_once())
+				return false;
 		return true;
 	}
 


### PR DESCRIPTION

* a specially constructed zstd frame could cause an infinite loop (-> crash the app). Oops
* attempts at optimizing bitmatrix (under the theory we were cache-limited) proved unsuccessful. But there are some small optimizations and bits of cleanup that fell out.
* added a unit test for bitmatrix... we were previously only testing it one level up as part of the decode.