### PR TITLE
CI for (beta) windows MSVC support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,30 +27,56 @@ jobs:
           env: CXX="clang++" CC="clang"
           extra-packages: "clang"
 
+        - name: "windows msvc"
+          os: windows-latest
+
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
-    - name: Install dependencies
+    - name: Install dependencies (linux)
+      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install libopencv-dev libglfw3-dev libgles2-mesa-dev ${{ matrix.config.extra-packages }}
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build
+        cmake -E make_directory ${{github.workspace}}/vcpkg-cache
 
-    - name: Configure CMake
+    - name: setup vcpkg cache (windows)
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/vcpkg-cache
+        key: vcpkg-cache-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          vcpkg-cache-${{ runner.os }}-
+
+    - name: Configure CMake (linux)
+      if: runner.os == 'Linux'
       working-directory: ${{runner.workspace}}/build
       run: ${{ matrix.config.env }} cmake $GITHUB_WORKSPACE
 
+    - name: Configure CMake (windows)
+      if: runner.os == 'Windows'
+      env:
+        VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg-cache,readwrite"
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $env:GITHUB_WORKSPACE -A x64 "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . && cmake --install .
+      run: |
+        cmake --build . --config Release
+        cmake --install . --config Release
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest --output-on-failure
 
     - name: Usage test
+      if: runner.os == 'Linux'
       working-directory: ${{runner.workspace}}/libcimbar/test/py
       run: python3 -m unittest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
 
+if(DEFINED CMAKE_TOOLCHAIN_FILE AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
+	set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON CACHE BOOL "Install vcpkg runtime dependencies with executables")
+endif()
+
 project ( libcimbar )
 enable_testing()
 
 if (MSVC)
-    add_compile_options(/FI "iso646.h")
+	add_compile_options(/FI "iso646.h" /utf-8)
 endif()
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
@@ -37,6 +41,16 @@ if(DEFINED USE_WASM)  # wasm build needs OPENCV_DIR defined
 else()  # if not wasm, go find opencv. 3 or 4 should both work
 	find_package(OpenCV REQUIRED)
 	include_directories(${OpenCV_INCLUDE_DIRS})
+endif()
+
+if(MSVC)
+	find_package(glfw3 CONFIG REQUIRED)
+	find_package(unofficial-angle CONFIG REQUIRED)
+	set(PLATFORM_GL unofficial::angle::libGLESv2 unofficial::angle::libEGL)
+	get_target_property(ANGLE_EGL_RELEASE_DLL unofficial::angle::libEGL IMPORTED_LOCATION_RELEASE)
+	get_target_property(ANGLE_EGL_DEBUG_DLL unofficial::angle::libEGL IMPORTED_LOCATION_DEBUG)
+else()
+	set(PLATFORM_GL GL)
 endif()
 
 if(DEFINED BUILD_PORTABLE_LINUX)
@@ -104,5 +118,10 @@ include_directories(
 foreach(proj ${PROJECTS})
 	add_subdirectory(${proj} build/${proj})
 endforeach()
+
+if(MSVC)
+	install(FILES "${ANGLE_EGL_RELEASE_DLL}" DESTINATION bin CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+	install(FILES "${ANGLE_EGL_DEBUG_DLL}" DESTINATION bin CONFIGURATIONS Debug)
+endif()
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Crucially, because the encoder compiles to asmjs and wasm, it can run on anythin
 * wirehair - https://github.com/catid/wirehair
 * zstd - https://github.com/facebook/zstd
 
-## Build
+## Build (linux dev)
 
 1. install opencv and GLFW. On ubuntu/debian, this looks like:
 ```
@@ -69,7 +69,7 @@ make install
 
 By default, libcimbar will try to install build products under `./dist/bin/`.
 
-### Windows (MSVC + vcpkg)
+### Build (windows MSVC + vcpkg)
 
 Install Visual Studio with the Desktop development with C++ workload, CMake 3.14 or newer, and [vcpkg](https://github.com/microsoft/vcpkg). Set `VCPKG_ROOT` to the vcpkg checkout, then configure and build from PowerShell:
 
@@ -81,7 +81,11 @@ cmake --install build-windows --config Release
 
 The included `vcpkg.json` installs OpenCV, GLFW, and ANGLE during configuration. The executables and their runtime DLLs are installed under `./dist/bin/`.
 
-To build cimbar.js (what cimbar.org uses), see [WASM](WASM.md).
+Note: native Windows is supported on a "best efforts" basis, so things may be a bit more buggy. (primary dev is for linux/android)
+
+### Build wasm (cimbar.js)
+
+To build cimbar.js (what cimbar.org uses), see [WASM](WASM.md). Or use the [latest release](https://github.com/sz3/libcimbar/releases/latest).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ make install
 
 By default, libcimbar will try to install build products under `./dist/bin/`.
 
+### Windows (MSVC + vcpkg)
+
+Install Visual Studio with the Desktop development with C++ workload, CMake 3.14 or newer, and [vcpkg](https://github.com/microsoft/vcpkg). Set `VCPKG_ROOT` to the vcpkg checkout, then configure and build from PowerShell:
+
+```
+cmake -S . -B build-windows -A x64 "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build-windows --config Release --target cimbar_send cimbar_recv cimbar_recv2 --parallel
+cmake --install build-windows --config Release
+```
+
+The included `vcpkg.json` installs OpenCV, GLFW, and ANGLE during configuration. The executables and their runtime DLLs are installed under `./dist/bin/`.
+
 To build cimbar.js (what cimbar.org uses), see [WASM](WASM.md).
 
 ## Usage

--- a/src/exe/cimbar/CMakeLists.txt
+++ b/src/exe/cimbar/CMakeLists.txt
@@ -23,11 +23,13 @@ target_link_libraries(cimbar
 	${CPPFILESYSTEM}
 )
 
-add_custom_command(
-	TARGET cimbar POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar> cimbar.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar>
-)
+if(NOT MSVC)
+	add_custom_command(
+		TARGET cimbar POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar> cimbar.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar>
+	)
+endif()
 
 install(
 	TARGETS cimbar

--- a/src/exe/cimbar_extract/CMakeLists.txt
+++ b/src/exe/cimbar_extract/CMakeLists.txt
@@ -18,11 +18,13 @@ target_link_libraries(cimbar_extract
 	${OPENCV_LIBS}
 )
 
-add_custom_command(
-	TARGET cimbar_extract POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_extract> cimbar_extract.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_extract>
-)
+if(NOT MSVC)
+	add_custom_command(
+		TARGET cimbar_extract POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_extract> cimbar_extract.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_extract>
+	)
+endif()
 
 install(
 	TARGETS cimbar_extract

--- a/src/exe/cimbar_recv/CMakeLists.txt
+++ b/src/exe/cimbar_recv/CMakeLists.txt
@@ -16,17 +16,26 @@ target_link_libraries(cimbar_recv
 	cimbar_js
 	extractor
 
-	GL
+	${PLATFORM_GL}
 	glfw
 	${OPENCV_LIBS}
 	opencv_videoio
 )
 
-add_custom_command(
-	TARGET cimbar_recv POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv> cimbar_recv.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv>
-)
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_recv POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_recv>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_recv POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv> cimbar_recv.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv>
+	)
+endif()
 
 install(
 	TARGETS cimbar_recv

--- a/src/exe/cimbar_recv2/CMakeLists.txt
+++ b/src/exe/cimbar_recv2/CMakeLists.txt
@@ -16,15 +16,29 @@ target_link_libraries(cimbar_recv2
 	cimbar_js
 	extractor
 
-	GL
+	${PLATFORM_GL}
 	glfw
 	${OPENCV_LIBS}
 	opencv_videoio
 )
 
-add_custom_command(
-	TARGET cimbar_recv2 POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv2> cimbar_recv2.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv2>
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_recv2 POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_recv2>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_recv2 POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_recv2> cimbar_recv2.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_recv2>
+	)
+endif()
+
+install(
+	TARGETS cimbar_recv2
+	DESTINATION bin
 )
 

--- a/src/exe/cimbar_send/CMakeLists.txt
+++ b/src/exe/cimbar_send/CMakeLists.txt
@@ -16,11 +16,20 @@ target_link_libraries(cimbar_send
 	cimbar_js
 )
 
-add_custom_command(
-	TARGET cimbar_send POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_send> cimbar_send.dbg
-	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_send>
-)
+if(MSVC)
+	add_custom_command(
+		TARGET cimbar_send POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			$<TARGET_FILE:unofficial::angle::libEGL>
+			$<TARGET_FILE_DIR:cimbar_send>
+	)
+else()
+	add_custom_command(
+		TARGET cimbar_send POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cimbar_send> cimbar_send.dbg
+		COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:cimbar_send>
+	)
+endif()
 
 install(
 	TARGETS cimbar_send

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -29,6 +29,10 @@ else()
 	)
 endif()
 
+if(MSVC)
+	target_compile_definitions(cimbar_js PUBLIC CIMBAR_USE_ANGLE)
+endif()
+
 target_link_libraries(cimbar_js
 
 	cimb_translator
@@ -111,7 +115,7 @@ if(DEFINED USE_WASM)
 
 else()  # if no wasm, ignore all that and add in GLFW libraries
 	target_link_libraries(cimbar_js
-		GL
+		${PLATFORM_GL}
 		glfw
 	)
 endif()

--- a/src/lib/gui/window_glfw.h
+++ b/src/lib/gui/window_glfw.h
@@ -30,6 +30,13 @@ public:
 			return;
 		}
 
+#ifdef CIMBAR_USE_ANGLE
+		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+		glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+#endif
+
 		_w = glfwCreateWindow(width, height, title.c_str(), NULL, NULL);
 		if (!_w)
 		{

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libcimbar",
+  "version-string": "0.6.7c",
+  "builtin-baseline": "ddd110b8a05cda14b8f1b0333a1d80c4fb6f16cd",
+  "dependencies": [
+    {
+      "name": "angle",
+      "platform": "windows & !mingw"
+    },
+    "glfw3",
+    "opencv4"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libcimbar",
   "version-string": "0.6.7c",
-  "builtin-baseline": "ddd110b8a05cda14b8f1b0333a1d80c4fb6f16cd",
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     {
       "name": "angle",


### PR DESCRIPTION
Building on #181. Add windows CI in github actions. Not *currently* planning on official windows builds, but it's nice to have for development purposes, and MSVC brings a different angle to compilation than g++/clang (which can be more annoying than useful.. but sometimes it's useful)

Anyway, the main trick/pain here is vcpkg caching.

*also*, this will momentarily break `master` CI checks, because there are some fixes that windows needs. Followup PR will appear shortly (https://github.com/sz3/libcimbar/actions/runs/31844154756) ... and here it is: #183