### PR TITLE
Fixes for (or inspired by) MSVC compiler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.h linguist-language=C++
+LICENSE text eol=lf

--- a/src/lib/compression/test/zstd_compressorTest.cpp
+++ b/src/lib/compression/test/zstd_compressorTest.cpp
@@ -15,7 +15,7 @@ using namespace cimbar;
 using namespace std;
 
 namespace {
-	using random_bytes_engine = std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char>;
+	using random_bytes_engine = std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned>;
 
 	string big_random(size_t size)
 	{

--- a/src/lib/encoder/DecoderPlus.h
+++ b/src/lib/encoder/DecoderPlus.h
@@ -24,7 +24,7 @@ inline unsigned DecoderPlus::decode(std::string filename, std::string output)
 	cv::Mat img = cv::imread(filename);
 	cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
 
-	std::ofstream f(output);
+	std::ofstream f(output,	std::ios::binary);
 	return Decoder::decode(img, f, false);
 }
 

--- a/src/lib/encoder/EncoderPlus.h
+++ b/src/lib/encoder/EncoderPlus.h
@@ -24,7 +24,7 @@ public:
 
 inline unsigned EncoderPlus::encode(const std::string& filename, std::string output_prefix)
 {
-	std::ifstream f(filename);
+	std::ifstream f(filename, std::ios::binary);
 
 	unsigned i = 0;
 	while (true)

--- a/src/lib/encoder/test/DecoderTest.cpp
+++ b/src/lib/encoder/test/DecoderTest.cpp
@@ -21,6 +21,17 @@ namespace {
 		picosha2::hash256(f, hash.begin(), hash.end());
 		return picosha2::bytes_to_hex_string(hash);
 	}
+
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
 }
 
 TEST_CASE( "DecoderTest/testDecode", "[unit]" )

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -37,7 +37,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	{
-		std::ofstream f(inputFile);
+		std::ofstream f(inputFile, std::ios::binary);
 		f << "hello"; // 5 bytes!
 	}
 
@@ -88,7 +88,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	std::string outPrefix = tempdir.path() / "encoder.fountain";
 
 	{
-		std::ofstream f(inputFile);
+		std::ofstream f(inputFile, std::ios::binary);
 		f << "hello"; // 5 bytes!
 	}
 

--- a/src/lib/encoder/test/EncoderRoundTripTest.cpp
+++ b/src/lib/encoder/test/EncoderRoundTripTest.cpp
@@ -16,6 +16,19 @@
 #include <iostream>
 #include <string>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
+
 TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 {
 	MakeTempDirectory tempdir;
@@ -41,7 +54,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 	SECTION ("default filename") {
 		// decoder
 		Decoder dec;
-		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 		unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 		assertEquals( 7500, bytesDecoded );
@@ -54,7 +67,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.Pad", "[unit]" )
 
 	SECTION ("parsed filename") {
 		Decoder dec;
-		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), decompress_on_store<std::ofstream>(tempdir.path()));
+		fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), decompress_on_store<std::ofstream>(tempdir.path().string()));
 
 		unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 		assertEquals( 7500, bytesDecoded );
@@ -94,7 +107,7 @@ TEST_CASE( "EncoderRoundTripTest/testFountain.SinkMismatch", "[unit]" )
 	// sink with a mismatched fountain_chunk_size
 	// importantly, the sink expects a *smaller* chunk than we'll give it...
 	// because that's a more interesting test...
-	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size()-125, write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size()-125, write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 	unsigned bytesDecoded = dec.decode_fountain(encodedImg, fds);
 	assertEquals( 7500, bytesDecoded );
@@ -117,7 +130,7 @@ TEST_CASE( "EncoderRoundTripTest/testStreaming", "[unit]" )
 
 	// create decoder
 	Decoder dec;
-	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path()));
+	fountain_decoder_sink fds(cimbar::Config::fountain_chunk_size(), write_on_store<cimbar::zstd_decompressor<std::ofstream>>(tempdir.path().string()));
 
 	// encode frames, then pass to decoder
 	for (int i = 0; i < 100; ++i)

--- a/src/lib/encoder/test/EncoderTest.cpp
+++ b/src/lib/encoder/test/EncoderTest.cpp
@@ -16,6 +16,18 @@
 #include <string>
 #include <vector>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
 
 TEST_CASE( "EncoderTest/testVanilla", "[unit]" )
 {

--- a/src/lib/extractor/test/ExtractorTest.cpp
+++ b/src/lib/extractor/test/ExtractorTest.cpp
@@ -9,6 +9,19 @@
 #include <string>
 #include <vector>
 
+namespace {
+	// evil hacks for MSVC
+	std::string operator/(const std::filesystem::path& lhs, const char* rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+
+	std::string operator/(const std::filesystem::path& lhs, const std::string& rhs)
+	{
+		return (lhs / std::filesystem::path(rhs)).string();
+	}
+}
+
 TEST_CASE( "ExtractorTest/testExtract", "[unit]" )
 {
 	MakeTempDirectory tempdir;

--- a/src/lib/fountain/FountainDecoder.h
+++ b/src/lib/fountain/FountainDecoder.h
@@ -14,7 +14,7 @@ class FountainDecoder
 {
 public:
 	FountainDecoder(size_t length, size_t packet_size)
-	    : _length(length)
+		: _length(length)
 	{
 		FountainInit::init();
 		_codec = wirehair_decoder_create(nullptr, length, packet_size);
@@ -22,7 +22,33 @@ public:
 
 	~FountainDecoder()
 	{
-		wirehair_free(_codec);
+		if (_codec)
+			wirehair_free(_codec);
+	}
+
+	// no copy
+	FountainDecoder(const FountainDecoder&) = delete;
+	FountainDecoder& operator=(const FountainDecoder&) = delete;
+
+	FountainDecoder(FountainDecoder&& other) noexcept
+		: _codec(std::exchange(other._codec, nullptr))
+		, _res(other._res)
+		, _length(other._length)
+		, _seenBlocks(std::move(other._seenBlocks))
+	{}
+
+	FountainDecoder& operator=(FountainDecoder&& other) noexcept
+	{
+		if (this != &other)
+		{
+			if (_codec)
+				wirehair_free(_codec);
+			_codec = std::exchange(other._codec, nullptr);
+			_res = other._res;
+			_length = other._length;
+			_seenBlocks = std::move(other._seenBlocks);
+		}
+		return *this;
 	}
 
 	unsigned progress() const
@@ -76,7 +102,7 @@ public:
 	}
 
 protected:
-	WirehairCodec _codec;
+	WirehairCodec _codec = nullptr;
 	WirehairResult _res;
 	size_t _length;
 	std::set<unsigned> _seenBlocks; // giving wirehair_decode the same block too many times can make it very, very upset

--- a/src/lib/fountain/FountainEncoder.h
+++ b/src/lib/fountain/FountainEncoder.h
@@ -7,16 +7,11 @@
 
 class FountainEncoder
 {
-protected:
-	void swap(FountainEncoder& other) throw()
-	{
-		std::swap(_codec, other._codec);
-		std::swap(_packetSize, other._packetSize);
-	}
-
 public:
+	FountainEncoder() = default;
+
 	FountainEncoder(const uint8_t* data, size_t length, size_t packet_size)
-	    : _packetSize(packet_size)
+		: _packetSize(packet_size)
 	{
 		FountainInit::init();
 		_codec = wirehair_encoder_create(nullptr, data, length, packet_size);
@@ -24,12 +19,28 @@ public:
 
 	~FountainEncoder()
 	{
-		wirehair_free(_codec);
+		if (_codec)
+			wirehair_free(_codec);
 	}
 
-	FountainEncoder& operator=(FountainEncoder temp)
+	// no copy
+	FountainEncoder(const FountainEncoder&) = delete;
+	FountainEncoder& operator=(const FountainEncoder&) = delete;
+
+	FountainEncoder(FountainEncoder&& other) noexcept
+		: _codec(std::exchange(other._codec, nullptr))
+		, _packetSize(other._packetSize)
+	{}
+
+	FountainEncoder& operator=(FountainEncoder&& other) noexcept
 	{
-		temp.swap(*this);
+		if (this != &other)
+		{
+			if (_codec)
+				wirehair_free(_codec);
+			_codec = std::exchange(other._codec, nullptr);
+			_packetSize = other._packetSize;
+		}
 		return *this;
 	}
 
@@ -54,6 +65,6 @@ public:
 	}
 
 protected:
-	WirehairCodec _codec;
+	WirehairCodec _codec = nullptr;
 	size_t _packetSize;
 };

--- a/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "FountainSinkSpecialTest/testMultipart", "[unit]" )
 	::srand( ::time(nullptr) );
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(750, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(750, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	const int totalSize = 6000000;
 	string randostr = random_string(2500);

--- a/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkSpecialTest.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "FountainSinkSpecialTest/testMultipart", "[unit]" )
 
 	const int totalSize = 6000000;
 	string randostr = random_string(2500);
-	std::cout << randostr << std::endl;
+	//std::cout << randostr << std::endl;
 	stringstream input = dummyContents(totalSize, randostr);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 750, 108);
 

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -54,7 +54,7 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 	string iframe = createFrame(0, 1200);
 	assertEquals( 6900, iframe.size() );
 
@@ -86,7 +86,7 @@ TEST_CASE( "FountainSinkTest/testMultipart", "[unit]" )
 {
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	stringstream input = dummyContents(20000);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 690, 2);
@@ -117,7 +117,7 @@ TEST_CASE( "FountainSinkTest/testSameFrameManyTimes", "[unit]" )
 	// sometimes it's fine. The docs say "don't do it", so FountainDecoder acts as the bouncer.
 	MakeTempDirectory tempdir;
 
-	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path()));
+	fountain_decoder_sink sink(690, write_on_store<std::ofstream>(tempdir.path().string()));
 
 	stringstream input = dummyContents(20000);
 	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 690, 3);

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -74,7 +74,11 @@ TEST_CASE( "FountainSinkTest/testDefault", "[unit]" )
 	assertEquals( 2, sink.num_done() );
 
 	assertEquals( "", turbo::str::join(sink.get_progress()) );
-	assertEquals( "1.1600 0.1200", turbo::str::join(sink.get_done()) );
+	{
+		auto res = sink.get_done();
+		std::sort(res.begin(), res.end());
+		assertEquals( "0.1200 1.1600", turbo::str::join(res) );
+	}
 
 	string contents = File(tempdir.path() / "0.1200").read_all();
 	assertEquals( 1200, contents.size() );

--- a/src/lib/util/File.h
+++ b/src/lib/util/File.h
@@ -16,9 +16,14 @@ public:
 	}
 
 public:
-	File(std::string filename, bool write=false)
+	File(const std::string& filename, bool write=false)
 	{
 		_fp = fopen(filename.c_str(), write? "wb" : "rb");
+	}
+
+	File(const std::filesystem::path& filename, bool write=false)
+		: File(filename.string(), write)
+	{
 	}
 
 	std::string read_all()


### PR DESCRIPTION
#181 , #182

Some of these, like the rule of 5 constructor/destructor sloppiness, were just plain wrong and taking advantage of g++/clang's friendliness. Others, like line endings and MSVC's lack of autoconversion of filesystem::path -> std::string, are... kinda maddening. Oh well