### PR TITLE
Reproducible wasm build + shader downgrade to GLES 100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 project ( libcimbar )
 enable_testing()
 
-if (MSVC)
-	add_compile_options(/FI "iso646.h" /utf-8)
-endif()
-
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -19,6 +15,14 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 add_definitions("-DLIBCIMBAR_PROJECT_ROOT=\"${libcimbar_SOURCE_DIR}\"")
+
+# reproducible build, hopefully
+if(NOT MSVC)
+	add_compile_options(
+		-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.
+		-ffile-prefix-map=${CMAKE_BINARY_DIR}=.
+	)
+endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 	set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -70,7 +74,10 @@ if(NOT DEFINED CPPFILESYSTEM)
 	set(CPPFILESYSTEM "stdc++fs")
 endif()
 
+# special snowflake MSVC section
 if(MSVC)
+	add_compile_options(/FI "iso646.h" /utf-8)
+
 	set(CPPFILESYSTEM "")
 endif()
 

--- a/package-wasm.sh
+++ b/package-wasm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-#docker run --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:5.0.0 bash
+#docker run -e SOURCE_DATE_EPOCH --mount type=bind,source="$(pwd)",target="/usr/src/app" -it emscripten/emsdk:5.0.0 bash
+# reproducible build, hopefully
 
+export SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(date +%s)}
 SKIP_JS=${SKIP_JS:-}
 CIMBAR_ROOT=${CIMBAR_ROOT:-/usr/src/app}
 cd $CIMBAR_ROOT

--- a/src/lib/cimbar_js/CMakeLists.txt
+++ b/src/lib/cimbar_js/CMakeLists.txt
@@ -87,8 +87,6 @@ endif()
 set (LINK_WASM_LIST
 	--bind -Os
 	${LINK_WASM_OPT}
-	-s USE_WEBGL2=1
-	-s MIN_WEBGL_VERSION=2
 	-s MAX_WEBGL_VERSION=2
 	-s USE_GLFW=3
 	-s WASM_BIGINT=1

--- a/src/lib/gui/gl_2d_display.h
+++ b/src/lib/gui/gl_2d_display.h
@@ -15,26 +15,25 @@ namespace cimbar {
 class gl_2d_display_program
 {
 protected:
-	static constexpr const char* VERTEX_SHADER_SRC = R"(#version 300 es
+	static constexpr const char* VERTEX_SHADER_SRC = R"(
 	uniform mat2 rot;
 	uniform vec2 tform;
-	in vec4 vert;
-	out vec2 texCoord;
+	attribute vec4 vert;
+	varying vec2 texCoord;
 	void main() {
-	   gl_Position = vec4(vert.x, vert.y, 0.0f, 1.0f);
+	   gl_Position = vec4(vert.x, vert.y, 0.0, 1.0);
 	   vec2 ori = vec2(vert.x, vert.y);
 	   ori *= rot;
-	   texCoord = vec2(1.0f - ori.x, 1.0f - ori.y) / 2.0;
+	   texCoord = vec2(1.0 - ori.x, 1.0 - ori.y) / 2.0;
 	   texCoord -= tform;
 	})";
 
-	static constexpr const char* FRAGMENT_SHADER_SRC = R"(#version 300 es
+	static constexpr const char* FRAGMENT_SHADER_SRC = R"(
 	precision mediump float;
 	uniform sampler2D tex;
-	in vec2 texCoord;
-	out vec4 finalColor;
+	varying vec2 texCoord;
 	void main() {
-	   finalColor = texture(tex, texCoord);
+	   gl_FragColor = texture2D(tex, texCoord);
 	})";
 
 public:

--- a/web/pwa-recv.json
+++ b/web/pwa-recv.json
@@ -4,7 +4,7 @@
 	"name": "cimbar.org Receiver",
 	"short_name": "cimbar recv",
 	"icons": [{"src":"icon-192x192.png","sizes":"192x192","type":"image/png"},{"src":"icon-512x512.png","sizes":"512x512","type":"image/png","purpose": "any"},{"src":"icon-512x512-maskable.png","sizes":"512x512","type":"image/png","purpose": "maskable"}],
-	"scope": "/",
+	"scope": "/recv.html",
 	"start_url": "/recv.html",
 	"display": "fullscreen",
 	"theme_color": "aliceblue",

--- a/web/recv.html
+++ b/web/recv.html
@@ -426,7 +426,7 @@
   <script type="text/javascript">
     Recv.init_ww(4);
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('./recv-sw.js');
+      navigator.serviceWorker.register('./recv-sw.js', { scope: '/recv.html' });
     }
     var video = document.querySelector('#video');
 

--- a/web/wasmgz.sh
+++ b/web/wasmgz.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # run from within web dir
 # does various renames for cache busting
+# reproducible build, hopefully
 
 RENAME_FILES=$(ls cimbar_js.js cimbar_js.wasm main.js send.js send-worker.js recv.js recv-worker.js zstd.js pwa*.json)
 GSUB_FILES="index.html recv.html sw.js recv-sw.js $(echo $RENAME_FILES | sed 's/cimbar_js\.wasm//g')"
 
-VERSION=${VERSION:-$(date --utc '+%Y-%m-%dT%H%M')}
+SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-$(date +%s)}
+VERSION=${VERSION:-$(date --utc -d "@$SOURCE_DATE_EPOCH" '+%Y-%m-%dT%H%M')}
 echo $VERSION
 
 mkdir $VERSION
@@ -32,4 +34,5 @@ for f in $(echo $RENAME_FILES | xargs -n 1 | sort -u); do
 	mv $f $newname
 done
 
-tar -czvf ../cimbar.wasm.tar.gz *
+# reproducible (hopefully) tar.gz
+find . -mindepth 1 | env LC_ALL=C sort | tar --transform='s|^\./||' --mtime="@${SOURCE_DATE_EPOCH:-0}" --owner=0 --group=0 --numeric-owner  --pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0 -c -T - | gzip -n > ../cimbar.wasm.tar.gz


### PR DESCRIPTION
Three parts:
* reproducible wasm build! This turns out to be *fairly* straightforward now. Mostly timestamp things (use SOURCE_DATE_EPOCH + make sure any tar/etc operations use a fixed timestamp), but also depends on the docker image used for the build.
    * caveat: depends on the emsdk docker image. We're currently tracking the "5.0.0" tag in the CI scripts.
* downgrade shader to use `es 100` -- turns out `es 300` is not necessary, which *maybe* will allow some older devices to run the web encoder?
* minor change to PWA json to allow send/recv to coexist. Sharing the same domain seems intractable (unfortunately), it looks like you have to install the recv app *first* to for both installs to work. ... probably wouldn't have done it this way if I'd known.