### PR TITLE
security hardening: small fountain_decoder fixes for bad inputs

### DIFF
--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -54,7 +54,7 @@ class fountain_decoder_sink
 {
 public:
 	fountain_decoder_sink(unsigned chunk_size, const std::function<std::string(const std::string&, const std::vector<uint8_t>&)>& on_store=nullptr)
-		: _chunkSize(chunk_size)
+		: _chunkSize(chunk_size < 50? 50 : chunk_size)
 		, _onStore(on_store)
 	{
 	}
@@ -132,15 +132,18 @@ public:
 
 	int64_t decode_frame(const char* data, unsigned size)
 	{
-		if (size < FountainMetadata::md_size)
+		if ((size%_chunkSize) > 0)
 			return -10;
+
+		if (size < FountainMetadata::md_size)
+			return -11;
 
 		FountainMetadata md(data, size);
 		if (!md.file_size())
 		{
 			/*std::cout << fmt::format("decode frame {} ... {},{},{},{}",
 									 md.file_size(), (unsigned)data[0], (unsigned)data[1], (unsigned)data[2], (unsigned)data[3]) << std::endl;*/
-			return -11;
+			return -12;
 		}
 
 		// check if already done
@@ -151,7 +154,7 @@ public:
 		auto p = _streams.try_emplace(stream_slot(md), md.file_size(), _chunkSize);
 		fountain_decoder_stream& s = p.first->second;
 		if (s.data_size() != md.file_size())
-			return -12;
+			return -13;
 
 		bool finished = s.write(data, size);
 		if (!finished)

--- a/src/lib/fountain/fountain_decoder_sink.h
+++ b/src/lib/fountain/fountain_decoder_sink.h
@@ -132,18 +132,16 @@ public:
 
 	int64_t decode_frame(const char* data, unsigned size)
 	{
-		if ((size%_chunkSize) > 0)
+		// 2nd clause is implicitly true iff 1st is... but leave it for clarity
+		if ((size%_chunkSize) > 0 or size < FountainMetadata::md_size)
 			return -10;
-
-		if (size < FountainMetadata::md_size)
-			return -11;
 
 		FountainMetadata md(data, size);
 		if (!md.file_size())
 		{
 			/*std::cout << fmt::format("decode frame {} ... {},{},{},{}",
 									 md.file_size(), (unsigned)data[0], (unsigned)data[1], (unsigned)data[2], (unsigned)data[3]) << std::endl;*/
-			return -12;
+			return -11;
 		}
 
 		// check if already done
@@ -154,7 +152,7 @@ public:
 		auto p = _streams.try_emplace(stream_slot(md), md.file_size(), _chunkSize);
 		fountain_decoder_stream& s = p.first->second;
 		if (s.data_size() != md.file_size())
-			return -13;
+			return -12;
 
 		bool finished = s.write(data, size);
 		if (!finished)

--- a/src/lib/fountain/fountain_decoder_stream.h
+++ b/src/lib/fountain/fountain_decoder_stream.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "FountainDecoder.h"
+#include "FountainMetadata.h"
 #include <optional>
 #include <string>
 
@@ -46,16 +47,13 @@ public:
 	{
 		// if we're full
 		_buffIndex = 0;
-		// we ignore the first 4 bytes. It's the sink's job to make sure we're getting the right stuff.
-		// we may, at some point, sanity check if data_size == [1]+[2]+[3]
-		unsigned blockId = (unsigned)(_buffer[4]) << 8 | _buffer[5];
-		return _decoder.decode(blockId, _buffer.data() + _headerSize, block_size());
+		FountainMetadata md(reinterpret_cast<const char*>(_buffer.data()), 6);
+		if (data_size() != md.file_size())
+			return false; // sanity check
+		return _decoder.decode(md.block_id(), _buffer.data() + _headerSize, block_size());
 	}
 
-	// we need to track either:
-	// 1. all packet header locations + current location in frame buffer to correlate
-	// 2. current location in frame buffer to see if we're at a packet header location
-	// 3. special case of #2, where we just roll forward every _bufferSize bytes?
+	// roll forward every _bufferSize bytes
 	bool write(const char* data, unsigned length)
 	{
 		while (length > 0 and good())

--- a/src/lib/fountain/test/fountain_sinkTest.cpp
+++ b/src/lib/fountain/test/fountain_sinkTest.cpp
@@ -143,3 +143,62 @@ TEST_CASE( "FountainSinkTest/testSameFrameManyTimes", "[unit]" )
 	assertEquals( "0.333333", turbo::str::join(sink.get_progress()) ); // 33% done
 	assertEquals( "", turbo::str::join(sink.get_done()) );
 }
+
+TEST_CASE( "FountainSinkTest/testRejection", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+	fountain_decoder_sink sink(625, write_on_store<std::ofstream>(tempdir.path().string()));
+
+	stringstream input1 = dummyContents(2000);
+	fountain_encoder_stream::ptr fes1 = fountain_encoder_stream::create(input1, 625, 1);
+
+	// a non-rejection, first
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// incomplete
+		assertEquals( 0, sink.decode_frame(buff.data(), buff.size()) );
+	}
+
+	// bad buffer sizes
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// smaller than fountain header
+		assertEquals( -10, sink.decode_frame(buff.data(), 5) );
+
+		// not the right chunk size
+		assertEquals( -10, sink.decode_frame(buff.data(), 620) );
+	}
+
+	// bad FountainMetadata
+	{
+		std::array<char, 625> buff;
+		unsigned res = fes1->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// extract and clobber
+		FountainMetadata md(buff.data(), FountainMetadata::md_size);
+		md = FountainMetadata(md.encode_id(), 0, md.block_id());
+		std::memcpy(buff.data(), md.data(), FountainMetadata::md_size);
+
+		assertEquals( -11, sink.decode_frame(buff.data(), buff.size()) );
+	}
+
+	// different size, same encode_id
+	{
+		stringstream input2 = dummyContents(1000);
+		fountain_encoder_stream::ptr fes2 = fountain_encoder_stream::create(input2, 625, 1);
+
+		std::array<char, 625> buff;
+		unsigned res = fes2->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		// slot taken
+		assertEquals( -12, sink.decode_frame(buff.data(), buff.size()) );
+	}
+}

--- a/src/lib/fountain/test/fountain_streamTest.cpp
+++ b/src/lib/fountain/test/fountain_streamTest.cpp
@@ -268,6 +268,49 @@ TEST_CASE( "FountainStreamTest/testDecode_BigPackets", "[unit]" )
 	assertEquals( 14, fes->block_count() );
 	assertEquals( 13, fes->blocks_required() );
 	assertTrue( fes->good() );
-
 }
+
+TEST_CASE( "FountainStreamTest/testDecode_RejectSizeMismatch", "[unit]" )
+{
+	stringstream input;
+	for (int i = 0; i < 100; ++i)
+		input << "0123456789";
+
+	fountain_encoder_stream::ptr fes = fountain_encoder_stream::create(input, 625);
+
+	assertEquals( 0, fes->block_count() );
+	assertEquals( 2, fes->blocks_required() );
+	assertTrue( fes->good() );
+
+	fountain_decoder_stream fdsgood(input.str().size(), 625);
+	fountain_decoder_stream fdsbad(input.str().size() + 7, 625); // size mismatch
+
+	std::array<char, 625> buff; // one block per read/write
+	for (int i = 0; i < 100; ++i)
+	{
+		unsigned res = fes->readsome(buff.data(), buff.size());
+		assertEquals( res, buff.size() );
+
+		assertFalse( fdsbad.write(buff.data(), buff.size()) ); // always reject on decode()
+
+		if (i < 2)
+		{
+			bool isdone = fdsgood.write(buff.data(), buff.size());
+			assertEquals( (i == 1), isdone );
+		}
+	}
+
+	assertEquals( 619, fdsgood.block_size() );
+	assertEquals( 1000, fdsgood.data_size() );
+	assertTrue( fdsgood.good() );
+
+	assertEquals( 619, fdsbad.block_size() );
+	assertEquals( 1007, fdsbad.data_size() );
+	assertTrue( fdsbad.good() );
+
+	assertEquals( 101, fes->block_count() );
+	assertEquals( 2, fes->blocks_required() );
+	assertTrue( fes->good() );
+}
+
 


### PR DESCRIPTION
These fall into the category of theoretical attacks -- but there were some assumptions baked in about inputs that aren't necessarily true (or won't be if the code is rearranged slightly).

These were inspired by #178 , which was presumably created accidentally and not really mergeable in that state anyway.  But +1 for AI security hardening I suppose 

