### PR TITLE
css cleanup (no "invisible-click" element) and seizure warning

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -98,6 +98,10 @@
       font: 1.5em serif;
     }
 
+    .drop-message .msg-long {
+      font: 1.0em serif;
+    }
+
     .drop-message .msg-bottom {
       margin-top: auto;
     }
@@ -356,8 +360,9 @@
     <div class="drop-message">
       <p class="msg-default">⌜ Tap to start! ⌟</p>
       <p class="msg-error">⌜ Error! WebGL is not enabled :( ⌟</p>
-      <p class="msg-default msg-bottom">⌜ WARNING: epilepsy = seizure risk!</p>
-      <p class="msg-default">Be safe! Have fun! ⌟</p>
+      <p class="msg-default msg-bottom">⌜ PHOTOSENSITIVITY WARNING!</p>
+      <p class="msg-default msg-long">Photosensitive epilepsy + flickering lights = seizures!</p>
+      <p class="msg-default msg-long">Be safe! Have fun! ⌟</p>
     </div>
     <canvas id="canvas" class="canvas"></canvas>
   </div>

--- a/web/index.html
+++ b/web/index.html
@@ -422,6 +422,10 @@
       };
     }
   </script>
+
+  <script type="text/javascript">
+    Main.check_GL_enabled();
+  </script>
   <script src="cimbar_js.js"></script>
 
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -40,18 +40,20 @@
     }
 
     #nav-container:focus-within {
-      z-index: 1;
+      z-index: 3;
     }
 
     #nav-content,
     #nav-container .bg,
     #nav-container:focus-within #nav-button {
-      z-index: 1;
+      z-index: 3;
     }
 
+    /* canvas/dragdrop */
     #canvas {
       display: block;
       position: relative;
+      z-index: 2;
     }
 
     #dragdrop {
@@ -61,35 +63,55 @@
       color: #F0F0F0;
       outline: 6px solid black;
       box-shadow: 0px 0px 12px black, 0px 0px 18px black;
+      position: relative;
+      cursor: pointer;
     }
 
-    .dragdrop::before {
-      content: "⌜ Tap to start! ⌟";
-      font: 1.5em serif;
-      padding-top: 2em;
+    #dragdrop.active,
+    #dragdrop.active * {
+      cursor: none !important;
+    }
+
+    .drop-message {
       position: absolute;
-      left: 0;
+      inset: 0;
+      z-index: 1;
+
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      padding-top: 3em;
+      padding-bottom: 2em;
       text-align: center;
-      width: 100%;
-    }
 
-    .dragdrop.error:before {
-      content: "⌜ Error! WebGL is not enabled :( ⌟";
-    }
-
-    #invisible_click {
-      position: fixed;
-      opacity: 0;
-      pointer-events: auto;
-    }
-
-    #invisible_click.active {
-      cursor: none;
-    }
-
-    #nav-container:focus-within+#invisible_click {
       pointer-events: none;
+    }
+
+    .drop-message p {
+      font: 1.3em serif;
+      margin: 0;
+      padding-bottom: 1em;
+    }
+
+    .drop-message p:first-of-type {
+      font: 1.5em serif;
+    }
+
+    .drop-message .msg-bottom {
+      margin-top: auto;
+    }
+
+    .drop-message .msg-error {
       display: none;
+    }
+
+    .dragdrop.error .drop-message .msg-default {
+      display: none;
+    }
+
+    .dragdrop.error .drop-message .msg-error {
+      display: block;
     }
 
     /* options */
@@ -330,16 +352,20 @@
   </style>
 
   <div id="status"></div>
-  <div id="dragdrop" class="dragdrop" title="Drag and drop a file">
+  <div id="dragdrop" class="dragdrop" title="Drag and drop a file" onclick="Main.clickNav()">
+    <div class="drop-message">
+      <p class="msg-default">⌜ Tap to start! ⌟</p>
+      <p class="msg-error">⌜ Error! WebGL is not enabled :( ⌟</p>
+      <p class="msg-default msg-bottom">⌜ WARNING: epilepsy = seizure risk!</p>
+      <p class="msg-default">Be safe! Have fun! ⌟</p>
+    </div>
     <canvas id="canvas" class="canvas"></canvas>
   </div>
 
   <input style="display:none;" type="file" name="file_input" id="file_input" onchange="Main.fileInput(this);" />
 
-  <a id="invisible_click" href="javascript:;" onclick="Main.clickNav()"></a>
-
   <div id="nav-container" class="mode-b">
-    <div class="bg" onclick="Main.blurNav();"></div>
+    <div class="bg" onpointerdown="Main.blurNav(); event.preventDefault();"></div>
     <button id="nav-button" tabindex="0" onclick="Main.clickNav();">
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -54,6 +54,7 @@
       display: block;
       position: relative;
       z-index: 2;
+      pointer-events: none;
     }
 
     #dragdrop {

--- a/web/index.html
+++ b/web/index.html
@@ -39,14 +39,15 @@
       top: 0;
     }
 
-    #nav-container:focus-within {
-      z-index: 3;
+    #nav-container {
+      z-index: 1;
     }
 
     #nav-content,
     #nav-container .bg,
+    #nav-container:focus-within,
     #nav-container:focus-within #nav-button {
-      z-index: 3;
+      z-index: 1;
     }
 
     /* canvas/dragdrop */
@@ -66,6 +67,7 @@
       box-shadow: 0px 0px 12px black, 0px 0px 18px black;
       position: relative;
       cursor: pointer;
+      z-index: 0;
     }
 
     #dragdrop.active,
@@ -90,7 +92,7 @@
     }
 
     .drop-message p {
-      font: 1.3em serif;
+      font: 1.2em serif;
       margin: 0;
       padding-bottom: 1em;
     }
@@ -100,7 +102,7 @@
     }
 
     .drop-message .msg-long {
-      font: 1.0em serif;
+      font: 0.9em serif;
     }
 
     .drop-message .msg-bottom {
@@ -361,9 +363,9 @@
     <div class="drop-message">
       <p class="msg-default">⌜ Tap to start! ⌟</p>
       <p class="msg-error">⌜ Error! WebGL is not enabled :( ⌟</p>
-      <p class="msg-default msg-bottom">⌜ PHOTOSENSITIVITY WARNING!</p>
-      <p class="msg-default msg-long">Photosensitive epilepsy + flickering lights = seizures!</p>
-      <p class="msg-default msg-long">Be safe! Have fun! ⌟</p>
+      <p class="msg-default msg-bottom">⚠️⚡ PHOTOSENSITIVITY WARNING!</p>
+      <p class="msg-default msg-long">Photosensitive epilepsy + flickering light = seizure!</p>
+      <p class="msg-default msg-long">Be safe! Have fun! ⚠️⚡</p>
     </div>
     <canvas id="canvas" class="canvas"></canvas>
   </div>

--- a/web/main.js
+++ b/web/main.js
@@ -110,7 +110,6 @@ var Main = function () {
       _ww.postMessage({ fun: 'nextFrame', args: [] });
     },
 
-
     check_GL_enabled: function () {
       var testCanvas = document.createElement('canvas');
       if (!testCanvas.getContext("webgl2") && !testCanvas.getContext("webgl")) {

--- a/web/main.js
+++ b/web/main.js
@@ -125,7 +125,6 @@ var Main = function () {
       var width = window.innerWidth - 10;
       var height = window.innerHeight - 10;
       Main.scaleCanvas(canvas, width, height);
-      Main.alignInvisibleClick(canvas);
       Main.checkNavButtonOverlap();
     },
 
@@ -174,17 +173,6 @@ var Main = function () {
         canvas.style.width = xdim + "px";
         canvas.style.height = ydim + "px";
       }
-    },
-
-    alignInvisibleClick: function (canvas) {
-      canvas = canvas || document.getElementById('canvas');
-      var cpos = canvas.getBoundingClientRect();
-      var invisible_click = document.getElementById("invisible_click");
-      invisible_click.style.width = canvas.style.width;
-      invisible_click.style.height = canvas.style.height;
-      invisible_click.style.top = cpos.top + "px";
-      invisible_click.style.left = cpos.left + "px";
-      invisible_click.style.zoom = canvas.style.zoom;
     },
 
     prevent_sleep: async function () {
@@ -267,9 +255,8 @@ var Main = function () {
 
     setActive: function (active) {
       // hide cursor when there's a barcode active
-      var invisi = document.getElementById("invisible_click");
-      invisi.classList.remove("active");
-      invisi.classList.add("active");
+      var invisi = document.getElementById("dragdrop");
+      dragdrop.classList.add("active");
     },
 
     setMode: function (mode_str) {

--- a/web/main.js
+++ b/web/main.js
@@ -229,9 +229,9 @@ var Main = function () {
       if (pause === undefined) {
         pause = true;
       }
-      document.getElementById("nav-button").blur();
-      document.getElementById("nav-content").blur();
-      document.getElementById("nav-find-file-link").blur();
+      if (document.activeElement && document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
       Main.togglePause(pause);
     },
 


### PR DESCRIPTION
#180 points out that cimbar could pose some danger to those with photosensitive epilepsy. I'm a *bit* skeptical of this being a problem during normal operation, where you're probably not staring at a bright screen but mostly checking in on your phone screen (which is "staring" at the screen). OTOH, if you're staring into the pretty static (#80) and have photosensitivity, you should probably reconsider...

*Anyway*, 15 fps is, AFAIK, right in the danger range. So we'll have a warning. I tried to keep it short and simple because nobody actually reads paragraphs of warning text.

(also didn't want an extra warning dialogue box to click through)


+ this requires some minor CSS changes. I also removed the "invisible-click" element hack to toggle the menu. (more extensive CSS rewrite for better keyboard/accessibility navigation will come soon)